### PR TITLE
feature/result-select

### DIFF
--- a/OnixLabs.Core.UnitTests/ResultNonGenericTests.cs
+++ b/OnixLabs.Core.UnitTests/ResultNonGenericTests.cs
@@ -238,6 +238,32 @@ public sealed class ResultNonGenericTests
     public void ResultSuccessSelectShouldProduceExpectedResult()
     {
         // Given
+        Result expected = Result.Success();
+
+        // When
+        Result actual = expected.Select(() => { });
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.Select should produce the expected result")]
+    public void ResultFailureSelectShouldProduceExpectedResult()
+    {
+        // Given
+        Result expected = Result.Failure(new Exception("Failure"));
+
+        // When
+        Result actual = expected.Select(() => { });
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.Select<TResult> should produce the expected result")]
+    public void ResultSuccessSelectTResultShouldProduceExpectedResult()
+    {
+        // Given
         const int expected = 9;
         Result result = Result.Success();
 
@@ -248,8 +274,8 @@ public sealed class ResultNonGenericTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(DisplayName = "Result Failure.Select should produce the expected result")]
-    public void ResultFailureSelectShouldProduceExpectedResult()
+    [Fact(DisplayName = "Result Failure.Select<TResult> should produce the expected result")]
+    public void ResultFailureSelectTResultShouldProduceExpectedResult()
     {
         // Given
         Exception exception = new("failure");
@@ -266,6 +292,32 @@ public sealed class ResultNonGenericTests
     public void ResultSuccessSelectManyShouldProduceExpectedResult()
     {
         // Given
+        Result expected = Result.Success();
+
+        // When
+        Result actual = expected.SelectMany(Result.Success);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.SelectMany should produce the expected result")]
+    public void ResultFailureSelectManyShouldProduceExpectedResult()
+    {
+        // Given
+        Result expected = Result.Failure(new Exception("Failure"));
+
+        // When
+        Result actual = expected.SelectMany(Result.Success);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.SelectMany<TResult> should produce the expected result")]
+    public void ResultSuccessSelectTResultManyShouldProduceExpectedResult()
+    {
+        // Given
         const int expected = 9;
         Result result = Result.Success();
 
@@ -276,8 +328,8 @@ public sealed class ResultNonGenericTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(DisplayName = "Result Failure.SelectMany should produce the expected result")]
-    public void ResultFailureSelectManyShouldProduceExpectedResult()
+    [Fact(DisplayName = "Result Failure.SelectMany<TResult> should produce the expected result")]
+    public void ResultFailureSelectTResultManyShouldProduceExpectedResult()
     {
         // Given
         Exception exception = new("failure");

--- a/OnixLabs.Core.UnitTests/ResultTests.cs
+++ b/OnixLabs.Core.UnitTests/ResultTests.cs
@@ -430,11 +430,11 @@ public sealed class ResultTests
     public void ResultSuccessSelectShouldProduceExpectedResult()
     {
         // Given
-        const int expected = 9;
-        Result<int> result = 3;
+        Result expected = Result.Success();
+        Result<int> result = 123;
 
         // When
-        Result<int> actual = result.Select(value => value * value);
+        Result actual = result.Select(_ => { });
 
         // Then
         Assert.Equal(expected, actual);
@@ -444,11 +444,40 @@ public sealed class ResultTests
     public void ResultFailureSelectShouldProduceExpectedResult()
     {
         // Given
+        Exception exception = new("Failure");
+        Result expected = Result.Failure(exception);
+        Result<int> result = Result<int>.Failure(exception);
+
+        // When
+        Result actual = result.Select(_ => { });
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.Select<TResult> should produce the expected result")]
+    public void ResultSuccessSelectTResultShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> expected = 9;
+        Result<int> result = 3;
+
+        // When
+        Result<int> actual = result.Select(x => x * x);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.Select<TResult> should produce the expected result")]
+    public void ResultFailureSelectTResultShouldProduceExpectedResult()
+    {
+        // Given
         Exception exception = new("failure");
         Result<int> result = Result<int>.Failure(exception);
 
         // When
-        Result<int> actual = result.Select(value => value * value);
+        Result<int> actual = result.Select(x => x * x);
 
         // Then
         Assert.Equal(Result<int>.Failure(exception), actual);
@@ -458,11 +487,11 @@ public sealed class ResultTests
     public void ResultSuccessSelectManyShouldProduceExpectedResult()
     {
         // Given
-        const int expected = 9;
+        Result expected = Result.Success();
         Result<int> result = 3;
 
         // When
-        Result<int> actual = result.SelectMany<int>(value => value * value);
+        Result actual = result.SelectMany(_ => Result.Success());
 
         // Then
         Assert.Equal(expected, actual);
@@ -472,11 +501,40 @@ public sealed class ResultTests
     public void ResultFailureSelectManyShouldProduceExpectedResult()
     {
         // Given
+        Exception exception = new("Failure");
+        Result expected = Result.Failure(exception);
+        Result<int> result = Result<int>.Failure(exception);
+
+        // When
+        Result actual = result.SelectMany(_ => Result.Success());
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.SelectMany<TResult> should produce the expected result")]
+    public void ResultSuccessSelectTResultManyShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> expected = 9;
+        Result<int> result = 3;
+
+        // When
+        Result<int> actual = result.SelectMany(x => Result<int>.Success(x * x));
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.SelectMany<TResult> should produce the expected result")]
+    public void ResultFailureSelectTResultManyShouldProduceExpectedResult()
+    {
+        // Given
         Exception exception = new("failure");
         Result<int> result = Result<int>.Failure(exception);
 
         // When
-        Result<int> actual = result.SelectMany<int>(value => value * value);
+        Result<int> actual = result.SelectMany(x => Result<int>.Success(x * x));
 
         // Then
         Assert.Equal(Result<int>.Failure(exception), actual);

--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -11,7 +11,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.7.0</PackageVersion>
+        <PackageVersion>8.8.0</PackageVersion>
         <PackageLicenseUrl></PackageLicenseUrl>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Core/Result.Failure.cs
+++ b/OnixLabs.Core/Result.Failure.cs
@@ -88,24 +88,40 @@ public sealed class Failure : Result, IValueEquatable<Failure>
     public override TResult Match<TResult>(Func<TResult> success, Func<Exception, TResult> failure) => failure(Exception);
 
     /// <summary>
+    /// Applies the provided selector action to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The action to apply to current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result Select(Action selector) => this;
+
+    /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> Select<TResult>(Func<TResult> selector) => Result<TResult>.Failure(Exception);
 
     /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The action to function to the current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result SelectMany(Func<Result> selector) => this;
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> SelectMany<TResult>(Func<Result<TResult>> selector) => Result<TResult>.Failure(Exception);
 
@@ -225,15 +241,13 @@ public sealed class Failure<T> : Result<T>, IValueEquatable<Failure<T>>
     public override TResult Match<TResult>(Func<T, TResult> success, Func<Exception, TResult> failure) => failure(Exception);
 
     /// <summary>
-    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// Applies the provided selector action to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
-    /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
+    /// <param name="selector">The action to apply to the value of the current <see cref="Result{T}"/> instance.</param>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public override Result<TResult> Select<TResult>(Func<T, TResult> selector) => Result<TResult>.Failure(Exception);
+    public override Result Select(Action<T> selector) => Result.Failure(Exception);
 
     /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
@@ -241,8 +255,26 @@ public sealed class Failure<T> : Result<T>, IValueEquatable<Failure<T>>
     /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
+    /// </returns>
+    public override Result<TResult> Select<TResult>(Func<T, TResult> selector) => Result<TResult>.Failure(Exception);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result SelectMany(Func<T, Result> selector) => Result.Failure(Exception);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
+    /// <returns>
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> SelectMany<TResult>(Func<T, Result<TResult>> selector) => Result<TResult>.Failure(Exception);
 

--- a/OnixLabs.Core/Result.Success.cs
+++ b/OnixLabs.Core/Result.Success.cs
@@ -89,24 +89,40 @@ public sealed class Success : Result, IValueEquatable<Success>
     public override TResult Match<TResult>(Func<TResult> success, Func<Exception, TResult> failure) => success();
 
     /// <summary>
+    /// Applies the provided selector action to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The action to apply to current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result Select(Action selector) => Of(selector);
+
+    /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> Select<TResult>(Func<TResult> selector) => selector();
 
     /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result SelectMany(Func<Result> selector) => selector();
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> SelectMany<TResult>(Func<Result<TResult>> selector) => selector();
 
@@ -229,24 +245,40 @@ public sealed class Success<T> : Result<T>, IValueEquatable<Success<T>>
     public override TResult Match<TResult>(Func<T, TResult> success, Func<Exception, TResult> failure) => success(Value);
 
     /// <summary>
-    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// Applies the provided selector action to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="selector">The action to apply to current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result Select(Action<T> selector) => Result.Of(() => selector(Value));
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> Select<TResult>(Func<T, TResult> selector) => selector(Value);
 
     /// <summary>
-    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public override Result SelectMany(Func<T, Result> selector) => selector(Value);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public override Result<TResult> SelectMany<TResult>(Func<T, Result<TResult>> selector) => selector(Value);
 

--- a/OnixLabs.Core/Result.cs
+++ b/OnixLabs.Core/Result.cs
@@ -172,24 +172,40 @@ public abstract class Result : IValueEquatable<Result>
     public abstract TResult Match<TResult>(Func<TResult> success, Func<Exception, TResult> failure);
 
     /// <summary>
+    /// Applies the provided selector action to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The action to apply to current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public abstract Result Select(Action selector);
+
+    /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public abstract Result<TResult> Select<TResult>(Func<TResult> selector);
 
     /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result"/> instance.</param>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public abstract Result SelectMany(Func<Result> selector);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public abstract Result<TResult> SelectMany<TResult>(Func<Result<TResult>> selector);
 
@@ -414,15 +430,13 @@ public abstract class Result<T> : IValueEquatable<Result<T>>
     public abstract TResult Match<TResult>(Func<T, TResult> success, Func<Exception, TResult> failure);
 
     /// <summary>
-    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// Applies the provided selector action to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
-    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
-    /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
+    /// <param name="selector">The action to apply to the value of the current <see cref="Result{T}"/> instance.</param>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public abstract Result<TResult> Select<TResult>(Func<T, TResult> selector);
+    public abstract Result Select(Action<T> selector);
 
     /// <summary>
     /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
@@ -430,8 +444,26 @@ public abstract class Result<T> : IValueEquatable<Result<T>>
     /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
-    /// Returns a new <see cref="Result{TResult}"/> instance containing the result of the function if the current
-    /// <see cref="Result{T}"/> instance is in a successful state; otherwise, returns the current failed <see cref="Result{T}"/> instance.
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
+    /// </returns>
+    public abstract Result<TResult> Select<TResult>(Func<T, TResult> selector);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <returns>
+    /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
+    /// </returns>
+    public abstract Result SelectMany(Func<T, Result> selector);
+
+    /// <summary>
+    /// Applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
+    /// <returns>
+    /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
     public abstract Result<TResult> SelectMany<TResult>(Func<T, Result<TResult>> selector);
 

--- a/OnixLabs.Numerics/OnixLabs.Numerics.csproj
+++ b/OnixLabs.Numerics/OnixLabs.Numerics.csproj
@@ -10,7 +10,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.7.0</PackageVersion>
+        <PackageVersion>8.8.0</PackageVersion>
         <LangVersion>12</LangVersion>
         <PackageLicenseUrl></PackageLicenseUrl>
     </PropertyGroup>

--- a/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
+++ b/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
@@ -10,7 +10,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.7.0</PackageVersion>
+        <PackageVersion>8.8.0</PackageVersion>
         <LangVersion>12</LangVersion>
         <PackageLicenseUrl></PackageLicenseUrl>
     </PropertyGroup>


### PR DESCRIPTION
Added `Select` and `SelectMany` functions to allow interchangeable `Result` to `Result<T>` transformations.