### PR TITLE
bugfix/optional-none

### DIFF
--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -7,11 +7,11 @@
         <Title>OnixLabs.Core</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Core API for .NET</Description>
-        <AssemblyVersion>8.10.0</AssemblyVersion>
+        <AssemblyVersion>8.10.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.10.0</PackageVersion>
+        <PackageVersion>8.10.1</PackageVersion>
     </PropertyGroup>
     <PropertyGroup>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/OnixLabs.Core/Optional.cs
+++ b/OnixLabs.Core/Optional.cs
@@ -26,7 +26,7 @@ public abstract class Optional<T> : IValueEquatable<Optional<T>> where T : notnu
     /// <summary>
     /// Gets a value indicating that the optional value is absent.
     /// </summary>
-    public static readonly None<T> None = new();
+    public static readonly Optional<T> None = new None<T>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Optional{T}"/> class.

--- a/OnixLabs.Numerics/OnixLabs.Numerics.csproj
+++ b/OnixLabs.Numerics/OnixLabs.Numerics.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Numerics</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Numerics API for .NET</Description>
-        <AssemblyVersion>8.10.0</AssemblyVersion>
+        <AssemblyVersion>8.10.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.10.0</PackageVersion>
+        <PackageVersion>8.10.1</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
+++ b/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security.Cryptography</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Cryptography API for .NET</Description>
-        <AssemblyVersion>8.10.0</AssemblyVersion>
+        <AssemblyVersion>8.10.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.10.0</PackageVersion>
+        <PackageVersion>8.10.1</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security/OnixLabs.Security.csproj
+++ b/OnixLabs.Security/OnixLabs.Security.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Security API for .NET</Description>
-        <AssemblyVersion>8.10.0</AssemblyVersion>
+        <AssemblyVersion>8.10.1</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.10.0</PackageVersion>
+        <PackageVersion>8.10.1</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Fixed bug: `Optional<T>.None` return type lowered from `None<T>` to `Optional<T>`.