### PR TITLE
feature/monad-result-disposable

### DIFF
--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -7,11 +7,11 @@
         <Title>OnixLabs.Core</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Core API for .NET</Description>
-        <AssemblyVersion>8.11.0</AssemblyVersion>
+        <AssemblyVersion>8.12.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.11.0</PackageVersion>
+        <PackageVersion>8.12.0</PackageVersion>
     </PropertyGroup>
     <PropertyGroup>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/OnixLabs.Core/Result.Failure.cs
+++ b/OnixLabs.Core/Result.Failure.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading.Tasks;
 
 namespace OnixLabs.Core;
 
@@ -288,4 +289,22 @@ public sealed class Failure<T> : Result<T>, IValueEquatable<Failure<T>>
     /// </summary>
     /// <returns>Returns a <see cref="String"/> that represents the current object.</returns>
     public override string ToString() => Exception.ToString();
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public override void Dispose()
+    {
+    }
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+    /// </summary>
+    /// <returns>
+    /// Returns a task that represents the asynchronous dispose operation.
+    /// </returns>
+    public override async ValueTask DisposeAsync()
+    {
+        await ValueTask.CompletedTask;
+    }
 }

--- a/OnixLabs.Core/Result.Success.cs
+++ b/OnixLabs.Core/Result.Success.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading.Tasks;
 
 namespace OnixLabs.Core;
 
@@ -294,4 +295,25 @@ public sealed class Success<T> : Result<T>, IValueEquatable<Success<T>>
     /// </summary>
     /// <returns>Returns a <see cref="String"/> that represents the current object.</returns>
     public override string ToString() => Value?.ToString() ?? string.Empty;
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public override void Dispose()
+    {
+        if (Value is IDisposable disposable)
+            disposable.Dispose();
+    }
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+    /// </summary>
+    /// <returns>
+    /// Returns a task that represents the asynchronous dispose operation.
+    /// </returns>
+    public override async ValueTask DisposeAsync()
+    {
+        if (Value is IAsyncDisposable disposable)
+            await disposable.DisposeAsync();
+    }
 }

--- a/OnixLabs.Core/Result.cs
+++ b/OnixLabs.Core/Result.cs
@@ -254,7 +254,7 @@ public abstract class Result : IValueEquatable<Result>
 /// Represents a result value, which signifies the presence of a value or an exception.
 /// </summary>
 /// <typeparam name="T">The type of the underlying result value.</typeparam>
-public abstract class Result<T> : IValueEquatable<Result<T>>
+public abstract class Result<T> : IValueEquatable<Result<T>>, IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Result{T}"/> class.
@@ -528,4 +528,17 @@ public abstract class Result<T> : IValueEquatable<Result<T>>
         Failure<T> failure => failure.ToString(),
         _ => base.ToString() ?? GetType().FullName ?? nameof(Result<T>)
     };
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public abstract void Dispose();
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+    /// </summary>
+    /// <returns>
+    /// Returns a task that represents the asynchronous dispose operation.
+    /// </returns>
+    public abstract ValueTask DisposeAsync();
 }

--- a/OnixLabs.Numerics/OnixLabs.Numerics.csproj
+++ b/OnixLabs.Numerics/OnixLabs.Numerics.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Numerics</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Numerics API for .NET</Description>
-        <AssemblyVersion>8.11.0</AssemblyVersion>
+        <AssemblyVersion>8.12.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.11.0</PackageVersion>
+        <PackageVersion>8.12.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
+++ b/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security.Cryptography</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Cryptography API for .NET</Description>
-        <AssemblyVersion>8.11.0</AssemblyVersion>
+        <AssemblyVersion>8.12.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.11.0</PackageVersion>
+        <PackageVersion>8.12.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security/OnixLabs.Security.csproj
+++ b/OnixLabs.Security/OnixLabs.Security.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Security API for .NET</Description>
-        <AssemblyVersion>8.11.0</AssemblyVersion>
+        <AssemblyVersion>8.12.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.11.0</PackageVersion>
+        <PackageVersion>8.12.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Added `IDisposable` and `IAsyncDisposable` to `Result<T>` to dispose of instances that contain `IDisposable` or `IAsyncDisposable` values.