### PR TITLE
feature/result-monad-updates

### DIFF
--- a/OnixLabs.Core.UnitTests/ResultExtensionTests.cs
+++ b/OnixLabs.Core.UnitTests/ResultExtensionTests.cs
@@ -20,6 +20,170 @@ namespace OnixLabs.Core.UnitTests;
 
 public sealed class ResultExtensionTests
 {
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefaultAsync should produce the expected result.")]
+    public async Task ResultSuccessGetExceptionOrDefaultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Result result = Result.Success();
+
+        // When
+        Exception? actual = await Task.FromResult(result).GetExceptionOrDefaultAsync();
+
+        // Then
+        Assert.Null(actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefaultAsync with default value should produce the expected result.")]
+    public async Task ResultSuccessGetExceptionOrDefaultAsyncWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Success();
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrDefaultAsync(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrThrowAsync should produce the expected result.")]
+    public async Task ResultSuccessGetExceptionOrThrowAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Result result = Result.Success();
+
+        // When
+        Exception exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Task.FromResult(result).GetExceptionOrThrowAsync());
+
+        // Then
+        Assert.Equal("The current result is not in a Failure state.", exception.Message);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefaultAsync should produce the expected result.")]
+    public async Task ResultFailureGetExceptionOrDefaultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception? actual = await Task.FromResult(result).GetExceptionOrDefaultAsync();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefaultAsync with default value should produce the expected result.")]
+    public async Task ResultFailureGetExceptionOrDefaultAsyncWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrDefaultAsync(new Exception("unexpected exception"));
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrThrowAsync should produce the expected result.")]
+    public async Task ResultFailureGetExceptionOrThrowAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrThrowAsync();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result<T> Success.GetExceptionOrDefaultAsync should produce the expected result.")]
+    public async Task ResultOfTSuccessGetExceptionOrDefaultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception? actual = await Task.FromResult(result).GetExceptionOrDefaultAsync();
+
+        // Then
+        Assert.Null(actual);
+    }
+
+    [Fact(DisplayName = "Result<T> Success.GetExceptionOrDefaultAsync with default value should produce the expected result.")]
+    public async Task ResultOfTSuccessGetExceptionOrDefaultAsyncWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrDefaultAsync(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result<T> Success.GetExceptionOrThrowAsync should produce the expected result.")]
+    public async Task ResultOfTSuccessGetExceptionOrThrowAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Task.FromResult(result).GetExceptionOrThrowAsync());
+
+        // Then
+        Assert.Equal("The current result is not in a Failure<T> state.", exception.Message);
+    }
+
+    [Fact(DisplayName = "Result<T> Failure.GetExceptionOrDefaultAsync should produce the expected result.")]
+    public async Task ResultOfTFailureGetExceptionOrDefaultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception? actual = await Task.FromResult(result).GetExceptionOrDefaultAsync();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result<T> Failure.GetExceptionOrDefaultAsync with default value should produce the expected result.")]
+    public async Task ResultOfTFailureGetExceptionOrDefaultAsyncWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrDefaultAsync(new Exception("unexpected exception"));
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result<T> Failure.GetExceptionOrThrowAsync should produce the expected result.")]
+    public async Task ResultOfTFailureGetExceptionOrThrowAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception actual = await Task.FromResult(result).GetExceptionOrThrowAsync();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Result.GetValueOrDefaultAsync should return the result value when the result is Success")]
     public async Task ResultGetValueOrDefaultAsyncShouldReturnResultValueWhenResultIsSuccess()
     {
@@ -68,6 +232,7 @@ public sealed class ResultExtensionTests
 
         // When
         int actualNumber = await numberTask.GetValueOrDefaultAsync(456);
+        // ReSharper disable once VariableCanBeNotNullable
         string? actualText = await textTask.GetValueOrDefaultAsync("xyz");
 
         // Then
@@ -842,5 +1007,50 @@ public sealed class ResultExtensionTests
 
         // When / Then
         await Assert.ThrowsAsync<Exception>(async () => await Task.FromResult(result).ThrowAsync());
+    }
+
+    [Fact(DisplayName = "Result Failure.ToTypedResultAsync should produce the expected result.")]
+    public async Task ResultFailureToTypedResultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure result = Result.Failure(exception);
+
+        // When
+        Result<int> actual = await Task.FromResult(result).ToTypedResultAsync<int>();
+
+        // Then
+        Assert.IsType<Failure<int>>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
+    }
+
+    [Fact(DisplayName = "Result<T> Failure.ToTypedResultAsync should produce the expected result.")]
+    public async Task ResultOfTFailureToTypedResultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure<string> result = Result<string>.Failure(exception);
+
+        // When
+        Result<int> actual = await Task.FromResult(result).ToTypedResultAsync<string, int>();
+
+        // Then
+        Assert.IsType<Failure<int>>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
+    }
+
+    [Fact(DisplayName = "Result<T> Failure.ToUntypedResultAsync should produce the expected result.")]
+    public async Task ResultOfTFailureToUntypedResultAsyncShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure<string> result = Result<string>.Failure(exception);
+
+        // When
+        Result actual = await Task.FromResult(result).ToUntypedResultAsync();
+
+        // Then
+        Assert.IsType<Failure>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
     }
 }

--- a/OnixLabs.Core.UnitTests/ResultGenericTests.cs
+++ b/OnixLabs.Core.UnitTests/ResultGenericTests.cs
@@ -351,6 +351,88 @@ public sealed class ResultGenericTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefault should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrDefaultShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception? actual = result.GetExceptionOrDefault();
+
+        // Then
+        Assert.Null(actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefault with default value should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrDefaultWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception actual = result.GetExceptionOrDefault(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrThrow should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrThrowShouldProduceExpectedResult()
+    {
+        // Given
+        Result<int> result = Result<int>.Success(123);
+
+        // When
+        Exception exception = Assert.Throws<InvalidOperationException>(() => result.GetExceptionOrThrow());
+
+        // Then
+        Assert.Equal("The current result is not in a Failure<T> state.", exception.Message);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefault should produce the expected result.")]
+    public void ResultFailureGetExceptionOrDefaultShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception? actual = result.GetExceptionOrDefault();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefault with default value should produce the expected result.")]
+    public void ResultFailureGetExceptionOrDefaultWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception actual = result.GetExceptionOrDefault(new Exception("unexpected exception"));
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrThrow should produce the expected result.")]
+    public void ResultFailureGetExceptionOrThrowShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result<int> result = Result<int>.Failure(expected);
+
+        // When
+        Exception actual = result.GetExceptionOrThrow();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Result Success.GetValueOrDefault should produce the expected result.")]
     public void ResultSuccessGetValueOrDefaultShouldProduceExpectedResult()
     {
@@ -681,6 +763,36 @@ public sealed class ResultGenericTests
         // Then
         Assert.Equal("System.Exception: failure", numberString);
         Assert.Equal("System.Exception: failure", textString);
+    }
+
+    [Fact(DisplayName = "Result Failure.ToTypedResult should produce the expected result.")]
+    public void ResultFailureToTypedResultShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure<string> result = Result<string>.Failure(exception);
+
+        // When
+        Result<int> actual = result.ToTypedResult<int>();
+
+        // Then
+        Assert.IsType<Failure<int>>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
+    }
+
+    [Fact(DisplayName = "Result Failure.ToUntypedResult should produce the expected result.")]
+    public void ResultFailureToUntypedResultShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure<string> result = Result<string>.Failure(exception);
+
+        // When
+        Result actual = result.ToUntypedResult();
+
+        // Then
+        Assert.IsType<Failure>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
     }
 
     [Fact(DisplayName = "Result Success.Dispose should dispose of the underlying value.")]

--- a/OnixLabs.Core.UnitTests/ResultTests.cs
+++ b/OnixLabs.Core.UnitTests/ResultTests.cs
@@ -230,6 +230,88 @@ public sealed class ResultTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefault should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrDefaultShouldProduceExpectedResult()
+    {
+        // Given
+        Result result = Result.Success();
+
+        // When
+        Exception? actual = result.GetExceptionOrDefault();
+
+        // Then
+        Assert.Null(actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrDefault with default value should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrDefaultWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Success();
+
+        // When
+        Exception actual = result.GetExceptionOrDefault(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Success.GetExceptionOrThrow with default value should produce the expected result.")]
+    public void ResultSuccessGetExceptionOrThrowShouldProduceExpectedResult()
+    {
+        // Given
+        Result result = Result.Success();
+
+        // When
+        Exception exception = Assert.Throws<InvalidOperationException>(() => result.GetExceptionOrThrow());
+
+        // Then
+        Assert.Equal("The current result is not in a Failure state.", exception.Message);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefault should produce the expected result.")]
+    public void ResultFailureGetExceptionOrDefaultShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception? actual = result.GetExceptionOrDefault();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrDefault with default value should produce the expected result.")]
+    public void ResultFailureGetExceptionOrDefaultWithDefaultValueShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception actual = result.GetExceptionOrDefault(new Exception("unexpected exception"));
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "Result Failure.GetExceptionOrThrow with default value should produce the expected result.")]
+    public void ResultFailureGetExceptionOrThrowShouldProduceExpectedResult()
+    {
+        // Given
+        Exception expected = new("failure");
+        Result result = Result.Failure(expected);
+
+        // When
+        Exception actual = result.GetExceptionOrThrow();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Result Success.Match should execute the some action.")]
     public void ResultSuccessMatchShouldExecuteSuccessAction()
     {
@@ -448,5 +530,20 @@ public sealed class ResultTests
 
         // Then
         Assert.Equal("System.Exception: failure", resultString);
+    }
+
+    [Fact(DisplayName = "Result Failure.ToTypedResult should produce the expected result.")]
+    public void ResultFailureToTypedResultShouldProduceExpectedResult()
+    {
+        // Given
+        Exception exception = new("failure");
+        Failure result = Result.Failure(exception);
+
+        // When
+        Result<int> actual = result.ToTypedResult<int>();
+
+        // Then
+        Assert.IsType<Failure<int>>(actual);
+        Assert.Equal("System.Exception: failure", actual.GetExceptionOrThrow().ToString());
     }
 }

--- a/OnixLabs.Core/Extensions.Result.cs
+++ b/OnixLabs.Core/Extensions.Result.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OnixLabs.Core;
@@ -25,17 +26,98 @@ namespace OnixLabs.Core;
 public static class ResultExtensions
 {
     /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public static async Task<Exception?> GetExceptionOrDefaultAsync(this Task<Result> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrDefault();
+
+    /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/>.</param>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result"/> is in a <see cref="Success"/> state.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public static async Task<Exception> GetExceptionOrDefaultAsync(this Task<Result> task, Exception defaultException, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrDefault(defaultException);
+
+    /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public static async Task<Exception> GetExceptionOrThrowAsync(this Task<Result> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrThrow();
+
+    /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public static async Task<Exception?> GetExceptionOrDefaultAsync<T>(this Task<Result<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrDefault();
+
+    /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public static async Task<Exception> GetExceptionOrDefaultAsync<T>(this Task<Result<T>> task, Exception defaultException, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrDefault(defaultException);
+
+    /// <summary>
+    /// Asynchronously gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public static async Task<Exception> GetExceptionOrThrowAsync<T>(this Task<Result<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetExceptionOrThrow();
+
+    /// <summary>
     /// Asynchronously gets the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;
     /// otherwise returns the default <typeparamref name="T"/> value.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/> value.</typeparam>
     /// <returns>
     /// Returns the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;
     /// otherwise returns the default <typeparamref name="T"/> value.
     /// </returns>
-    public static async Task<T?> GetValueOrDefaultAsync<T>(this Task<Result<T>> task) =>
-        (await task.ConfigureAwait(false)).GetValueOrDefault();
+    public static async Task<T?> GetValueOrDefaultAsync<T>(this Task<Result<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetValueOrDefault();
 
     /// <summary>
     /// Asynchronously gets the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;
@@ -43,26 +125,28 @@ public static class ResultExtensions
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
     /// <param name="defaultValue">The default value to return in the event that the underlying value is absent.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/> value.</typeparam>
     /// <returns>
     /// Returns the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;
     /// otherwise returns the specified default value.
     /// </returns>
-    public static async Task<T> GetValueOrDefaultAsync<T>(this Task<Result<T>> task, T defaultValue) =>
-        (await task.ConfigureAwait(false)).GetValueOrDefault(defaultValue);
+    public static async Task<T> GetValueOrDefaultAsync<T>(this Task<Result<T>> task, T defaultValue, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetValueOrDefault(defaultValue);
 
     /// <summary>
     /// Asynchronously gets the underlying value of the current <see cref="Result{T}"/> instance;
     /// otherwise throws the underlying exception if the current <see cref="Result{T}"/> is in a failed stated.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/> value.</typeparam>
     /// <returns>
     /// Returns the underlying value of the current <see cref="Result{T}"/> instance;
     /// otherwise throws the underlying exception if the current <see cref="Result{T}"/> is in a failed stated.
     /// </returns>
-    public static async Task<T> GetValueOrThrowAsync<T>(this Task<Result<T>> task) =>
-        (await task.ConfigureAwait(false)).GetValueOrThrow();
+    public static async Task<T> GetValueOrThrowAsync<T>(this Task<Result<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetValueOrThrow();
 
     /// <summary>
     /// Gets the <see cref="Optional{T}"/> value of the current <see cref="Result{T}"/> instance,
@@ -82,13 +166,14 @@ public static class ResultExtensions
     /// or <see cref="Optional{T}.None"/> if the result is in a <see cref="Failure{T}"/> state.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to obtain the <see cref="Optional{T}"/> value.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Optional{T}"/> value.</typeparam>
     /// <returns>
     /// Return the <see cref="Optional{T}"/> value of the current <see cref="Result{T}"/> instance,
     /// or <see cref="Optional{T}.None"/> if the result is in a <see cref="Failure{T}"/> state.
     /// </returns>
-    public static async Task<Optional<T>> GetValueOrNoneAsync<T>(this Task<Result<Optional<T>>> task) where T : notnull =>
-        (await task.ConfigureAwait(false)).GetValueOrNone();
+    public static async Task<Optional<T>> GetValueOrNoneAsync<T>(this Task<Result<Optional<T>>> task, CancellationToken token = default) where T : notnull =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetValueOrNone();
 
     /// <summary>
     /// Gets the underlying <typeparamref name="T"/> value from the current <see cref="Result{T}"/> of <see cref="Optional{T}"/>,
@@ -108,13 +193,14 @@ public static class ResultExtensions
     /// or throws an exception if the result is in a <see cref="Failure{T}"/> state, or the <see cref="Optional{T}"/> is <see cref="Optional{T}.None"/>.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to obtain the <see cref="Optional{T}"/> value.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Optional{T}"/> value.</typeparam>
     /// <returns>
     /// Returns the underlying <typeparamref name="T"/> value from the current <see cref="Result{T}"/> of <see cref="Optional{T}"/>,
     /// or throws an exception if the result is in a <see cref="Failure{T}"/> state, or the <see cref="Optional{T}"/> is <see cref="Optional{T}.None"/>.
     /// </returns>
-    public static async Task<T> GetOptionalValueOrThrowAsync<T>(this Task<Result<Optional<T>>> task) where T : notnull =>
-        (await task.ConfigureAwait(false)).GetOptionalValueOrThrow();
+    public static async Task<T> GetOptionalValueOrThrowAsync<T>(this Task<Result<Optional<T>>> task, CancellationToken token = default) where T : notnull =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetOptionalValueOrThrow();
 
     /// <summary>
     /// Gets the underlying <typeparamref name="T"/> value from the current <see cref="Result{T}"/> of <see cref="Optional{T}"/>,
@@ -136,13 +222,14 @@ public static class ResultExtensions
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to obtain the <see cref="Optional{T}"/> value.</param>
     /// <param name="defaultValue">The default value to return if the result is in a <see cref="Failure{T}"/> state, or the <see cref="Optional{T}"/> is <see cref="Optional{T}.None"/>.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Optional{T}"/> value.</typeparam>
     /// <returns>
     /// Returns the underlying <typeparamref name="T"/> value from the current <see cref="Result{T}"/> of <see cref="Optional{T}"/>,
     /// or returns the default value if the result is in a <see cref="Failure{T}"/> state, or the <see cref="Optional{T}"/> is <see cref="Optional{T}.None"/>.
     /// </returns>
-    public static async Task<T> GetOptionalValueOrDefaultAsync<T>(this Task<Result<Optional<T>>> task, T defaultValue) where T : notnull =>
-        (await task.ConfigureAwait(false)).GetOptionalValueOrDefault(defaultValue);
+    public static async Task<T> GetOptionalValueOrDefaultAsync<T>(this Task<Result<Optional<T>>> task, T defaultValue, CancellationToken token = default) where T : notnull =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).GetOptionalValueOrDefault(defaultValue);
 
     /// <summary>
     /// Asynchronously executes the action that matches the value of the current <see cref="Result"/> instance.
@@ -150,8 +237,9 @@ public static class ResultExtensions
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> from which to execute the matching function.</param>
     /// <param name="success">The action to execute when the current <see cref="Result"/> instance is in a successful state.</param>
     /// <param name="failure">The action to execute when the current <see cref="Result"/> instance is in a failed state.</param>
-    public static async Task MatchAsync(this Task<Result> task, Action? success = null, Action<Exception>? failure = null) =>
-        (await task.ConfigureAwait(false)).Match(success, failure);
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    public static async Task MatchAsync(this Task<Result> task, Action? success = null, Action<Exception>? failure = null, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Match(success, failure);
 
     /// <summary>
     /// Asynchronously executes the function that matches the value of the current <see cref="Result"/> instance and returns its result.
@@ -159,13 +247,14 @@ public static class ResultExtensions
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> from which to execute the matching function.</param>
     /// <param name="success">The action to execute when the current <see cref="Result"/> instance is in a successful state.</param>
     /// <param name="failure">The action to execute when the current <see cref="Result"/> instance is in a failed state.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the matching function.</typeparam>
     /// <returns>
     /// Returns the result of the <paramref name="success"/> function if the current <see cref="Result"/> instance is in a successful state;
     /// otherwise, returns the result of the <paramref name="failure"/> function if the current <see cref="Result"/> instance is in a failed state.
     /// </returns>
-    public static async Task<TResult> MatchAsync<TResult>(this Task<Result> task, Func<TResult> success, Func<Exception, TResult> failure) =>
-        (await task.ConfigureAwait(false)).Match(success, failure);
+    public static async Task<TResult> MatchAsync<TResult>(this Task<Result> task, Func<TResult> success, Func<Exception, TResult> failure, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Match(success, failure);
 
     /// <summary>
     /// Asynchronously executes the action that matches the value of the current <see cref="Result{T}"/> instance.
@@ -173,9 +262,10 @@ public static class ResultExtensions
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to execute the matching action.</param>
     /// <param name="success">The action to execute when the current <see cref="Result{T}"/> instance is in a successful state.</param>
     /// <param name="failure">The action to execute when the current <see cref="Result{T}"/> instance is in a failed state.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
-    public static async Task MatchAsync<T>(this Task<Result<T>> task, Action<T>? success = null, Action<Exception>? failure = null) =>
-        (await task.ConfigureAwait(false)).Match(success, failure);
+    public static async Task MatchAsync<T>(this Task<Result<T>> task, Action<T>? success = null, Action<Exception>? failure = null, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Match(success, failure);
 
     /// <summary>
     /// Asynchronously executes the function that matches the value of the current <see cref="Result{T}"/> instance and returns its result.
@@ -183,120 +273,164 @@ public static class ResultExtensions
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to execute the matching function.</param>
     /// <param name="success">The action to execute when the current <see cref="Result{T}"/> instance is in a successful state.</param>
     /// <param name="failure">The action to execute when the current <see cref="Result{T}"/> instance is in a failed state.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
     /// <typeparam name="TResult">The underlying type of the result produced by the matching function.</typeparam>
     /// <returns>
     /// Returns the result of the <paramref name="success"/> function if the current <see cref="Result{T}"/> instance is in a successful state;
     /// otherwise, returns the result of the <paramref name="failure"/> function if the current <see cref="Result{T}"/> instance is in a failed state.
     /// </returns>
-    public static async Task<TResult> MatchAsync<T, TResult>(this Task<Result<T>> task, Func<T, TResult> success, Func<Exception, TResult> failure) =>
-        (await task.ConfigureAwait(false)).Match(success, failure);
+    public static async Task<TResult> MatchAsync<T, TResult>(this Task<Result<T>> task, Func<T, TResult> success, Func<Exception, TResult> failure, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Match(success, failure);
 
     /// <summary>
     /// Asynchronously applies the provided selector action to the value of the current <see cref="Result"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> upon which to apply the selector action.</param>
     /// <param name="selector">The action to apply to current <see cref="Result"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <returns>
     /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public static async Task<Result> SelectAsync(this Task<Result> task, Action selector) =>
-        (await task.ConfigureAwait(false)).Select(selector);
+    public static async Task<Result> SelectAsync(this Task<Result> task, Action selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Select(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
     /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
-    public static async Task<Result<TResult>> SelectAsync<TResult>(this Task<Result> task, Func<TResult> selector) =>
-        (await task.ConfigureAwait(false)).Select(selector);
+    public static async Task<Result<TResult>> SelectAsync<TResult>(this Task<Result> task, Func<TResult> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Select(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector action to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> upon which to apply the selector action.</param>
     /// <param name="selector">The action to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <returns>
     /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the action invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public static async Task<Result> SelectAsync<T>(this Task<Result<T>> task, Action<T> selector) =>
-        (await task.ConfigureAwait(false)).Select(selector);
+    public static async Task<Result> SelectAsync<T>(this Task<Result<T>> task, Action<T> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Select(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
     /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
-    public static async Task<Result<TResult>> SelectAsync<T, TResult>(this Task<Result<T>> task, Func<T, TResult> selector) =>
-        (await task.ConfigureAwait(false)).Select(selector);
+    public static async Task<Result<TResult>> SelectAsync<T, TResult>(this Task<Result<T>> task, Func<T, TResult> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Select(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <returns>
     /// Returns <see cref="Success"/> if the current <see cref="Result"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public static async Task<Result> SelectManyAsync(this Task<Result> task, Func<Result> selector) =>
-        (await task.ConfigureAwait(false)).SelectMany(selector);
+    public static async Task<Result> SelectManyAsync(this Task<Result> task, Func<Result> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).SelectMany(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the current <see cref="Result"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
     /// Returns <see cref="Success{T}"/> if the current <see cref="Result"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
-    public static async Task<Result<TResult>> SelectManyAsync<TResult>(this Task<Result> task, Func<Result<TResult>> selector) =>
-        (await task.ConfigureAwait(false)).SelectMany(selector);
+    public static async Task<Result<TResult>> SelectManyAsync<TResult>(this Task<Result> task, Func<Result<TResult>> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).SelectMany(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
     /// <returns>
     /// Returns <see cref="Success"/> if the current <see cref="Result{T}"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure"/>.
     /// </returns>
-    public static async Task<Result> SelectManyAsync<T>(this Task<Result<T>> task, Func<T, Result> selector) =>
-        (await task.ConfigureAwait(false)).SelectMany(selector);
+    public static async Task<Result> SelectManyAsync<T>(this Task<Result<T>> task, Func<T, Result> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).SelectMany(selector);
 
     /// <summary>
     /// Asynchronously applies the provided selector function to the value of the current <see cref="Result{T}"/> instance.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> upon which to apply the selector function.</param>
     /// <param name="selector">The function to apply to the value of the current <see cref="Result{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
     /// <typeparam name="TResult">The underlying type of the result produced by the selector function.</typeparam>
     /// <returns>
     /// Returns <see cref="Success{T}"/> if the current <see cref="Result{T}"/> is in a successful state, and the function invocation is also successful; otherwise; <see cref="Failure{T}"/>.
     /// </returns>
-    public static async Task<Result<TResult>> SelectManyAsync<T, TResult>(this Task<Result<T>> task, Func<T, Result<TResult>> selector) =>
-        (await task.ConfigureAwait(false)).SelectMany(selector);
+    public static async Task<Result<TResult>> SelectManyAsync<T, TResult>(this Task<Result<T>> task, Func<T, Result<TResult>> selector, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).SelectMany(selector);
 
     /// <summary>
     /// Asynchronously throws the underlying exception if the current <see cref="Result"/> is in a failure state.
     /// </summary>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result"/> from which to throw the underlying exception.</param>
-    public static async Task ThrowAsync(this Task<Result> task) => (await task.ConfigureAwait(false)).Throw();
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    public static async Task ThrowAsync(this Task<Result> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Throw();
 
     /// <summary>
     /// Asynchronously throws the underlying exception if the current <see cref="Result{T}"/> is in a failure state.
     /// </summary>
     /// <typeparam name="T">The underlying type of the <see cref="Result{T}"/>.</typeparam>
     /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Result{T}"/> from which to throw the underlying exception.</param>
-    public static async Task ThrowAsync<T>(this Task<Result<T>> task) => (await task.ConfigureAwait(false)).Throw();
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    public static async Task ThrowAsync<T>(this Task<Result<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).Throw();
+
+    /// <summary>
+    /// Asynchronously obtains a new <see cref="Failure{T}"/> instance containing the current exception.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Failure"/> from which to obtain a typed <see cref="Failure{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <typeparam name="TResult">The underlying type of the <see cref="Failure{T}"/> to return.</typeparam>
+    /// <returns>Returns a new <see cref="Failure{T}"/> instance containing the current exception.</returns>
+    public static async Task<Failure<TResult>> ToTypedResultAsync<TResult>(this Task<Failure> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).ToTypedResult<TResult>();
+
+    /// <summary>
+    /// Asynchronously obtains a new <see cref="Failure{T}"/> instance containing the current exception.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Failure{T}"/> from which to obtain a typed <see cref="Failure{T}"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// /// <typeparam name="T">The underlying type of the current <see cref="Failure{T}"/>.</typeparam>
+    /// <typeparam name="TResult">The underlying type of the <see cref="Failure{T}"/> to return.</typeparam>
+    /// <returns>Returns a new <see cref="Failure{T}"/> instance containing the current exception.</returns>
+    public static async Task<Failure<TResult>> ToTypedResultAsync<T, TResult>(this Task<Failure<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).ToTypedResult<TResult>();
+
+    /// <summary>
+    /// Asynchronously obtains a new <see cref="Failure"/> instance containing the current exception.
+    /// </summary>
+    /// <param name="task">The current <see cref="Task{TResult}"/> of <see cref="Failure{T}"/> from which to obtain an untyped <see cref="Failure"/> instance.</param>
+    /// <param name="token">The cancellation token that can be used to cancel long-running tasks.</param>
+    /// <typeparam name="T">The underlying type of the current <see cref="Failure{T}"/>.</typeparam>
+    /// <returns>Returns a new <see cref="Failure"/> instance containing the current exception.</returns>
+    public static async Task<Failure> ToUntypedResultAsync<T>(this Task<Failure<T>> task, CancellationToken token = default) =>
+        (await task.WaitAsync(token).ConfigureAwait(false)).ToUntypedResult();
 }

--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -7,11 +7,11 @@
         <Title>OnixLabs.Core</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Core API for .NET</Description>
-        <AssemblyVersion>8.14.0</AssemblyVersion>
+        <AssemblyVersion>8.15.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.14.0</PackageVersion>
+        <PackageVersion>8.15.0</PackageVersion>
     </PropertyGroup>
     <PropertyGroup>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/OnixLabs.Core/Result.Failure.cs
+++ b/OnixLabs.Core/Result.Failure.cs
@@ -79,6 +79,38 @@ public sealed class Failure : Result, IValueEquatable<Failure>
     public override int GetHashCode() => Exception.GetHashCode();
 
     /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault() => Exception;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result"/> is in a <see cref="Success"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault(Exception defaultException) => Exception;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result"/> is in a <see cref="Success"/> state.</exception>
+    public override Exception GetExceptionOrThrow() => Exception;
+
+    /// <summary>
     /// Executes the action that matches the value of the current <see cref="Result"/> instance.
     /// <remarks>In the case of a failure, the failure branch is invoked.</remarks>
     /// </summary>
@@ -151,6 +183,13 @@ public sealed class Failure : Result, IValueEquatable<Failure>
     /// </summary>
     /// <returns>Returns a <see cref="String"/> that represents the current object.</returns>
     public override string ToString() => Exception.ToString();
+
+    /// <summary>
+    /// Obtains a new <see cref="Failure{T}"/> instance containing the current exception.
+    /// </summary>
+    /// <typeparam name="TResult">The underlying type of the <see cref="Failure{T}"/> to return.</typeparam>
+    /// <returns>Returns a new <see cref="Failure{T}"/> instance containing the current exception.</returns>
+    public Failure<TResult> ToTypedResult<TResult>() => Result<TResult>.Failure(Exception);
 }
 
 /// <summary>
@@ -205,6 +244,38 @@ public sealed class Failure<T> : Result<T>, IValueEquatable<Failure<T>>
     /// </summary>
     /// <returns>Returns a hash code for the current instance.</returns>
     public override int GetHashCode() => Exception.GetHashCode();
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault() => Exception;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault(Exception defaultException) => Exception;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</exception>
+    public override Exception GetExceptionOrThrow() => Exception;
 
     /// <summary>
     /// Gets the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;
@@ -310,6 +381,19 @@ public sealed class Failure<T> : Result<T>, IValueEquatable<Failure<T>>
     /// </summary>
     /// <returns>Returns a <see cref="String"/> that represents the current object.</returns>
     public override string ToString() => Exception.ToString();
+
+    /// <summary>
+    /// Obtains a new <see cref="Failure{T}"/> instance containing the current exception.
+    /// </summary>
+    /// <typeparam name="TResult">The underlying type of the <see cref="Failure{T}"/> to return.</typeparam>
+    /// <returns>Returns a new <see cref="Failure{T}"/> instance containing the current exception.</returns>
+    public Failure<TResult> ToTypedResult<TResult>() => Result<TResult>.Failure(Exception);
+
+    /// <summary>
+    /// Obtains a new <see cref="Failure"/> instance containing the current exception.
+    /// </summary>
+    /// <returns>Returns a new <see cref="Failure"/> instance containing the current exception.</returns>
+    public Failure ToUntypedResult() => Result.Failure(Exception);
 
     /// <summary>
     /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/OnixLabs.Core/Result.Success.cs
+++ b/OnixLabs.Core/Result.Success.cs
@@ -71,6 +71,38 @@ public sealed class Success : Result, IValueEquatable<Success>
     public override int GetHashCode() => default;
 
     /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public override Exception? GetExceptionOrDefault() => null;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result"/> is in a <see cref="Success"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault(Exception defaultException) => defaultException;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result"/> is in a <see cref="Success"/> state.</exception>
+    public override Exception GetExceptionOrThrow() => throw new InvalidOperationException("The current result is not in a Failure state.");
+
+    /// <summary>
     /// Executes the action that matches the value of the current <see cref="Result"/> instance.
     /// <remarks>In the case of a success, the success branch is invoked.</remarks>
     /// </summary>
@@ -200,6 +232,38 @@ public sealed class Success<T> : Result<T>, IValueEquatable<Success<T>>
     /// </summary>
     /// <returns>Returns a hash code for the current instance.</returns>
     public override int GetHashCode() => Value?.GetHashCode() ?? default;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public override Exception? GetExceptionOrDefault() => null;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public override Exception GetExceptionOrDefault(Exception defaultException) => defaultException;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</exception>
+    public override Exception GetExceptionOrThrow() => throw new InvalidOperationException("The current result is not in a Failure<T> state.");
 
     /// <summary>
     /// Gets the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;

--- a/OnixLabs.Core/Result.cs
+++ b/OnixLabs.Core/Result.cs
@@ -177,6 +177,38 @@ public abstract class Result : IValueEquatable<Result>
     public override int GetHashCode() => default;
 
     /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public abstract Exception? GetExceptionOrDefault();
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result"/> is in a <see cref="Success"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    public abstract Exception GetExceptionOrDefault(Exception defaultException);
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result"/> is in a <see cref="Failure"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result"/> is in a <see cref="Success"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result"/> is in a <see cref="Success"/> state.</exception>
+    public abstract Exception GetExceptionOrThrow();
+
+    /// <summary>
     /// Executes the action that matches the value of the current <see cref="Result"/> instance.
     /// </summary>
     /// <param name="success">The action to execute when the current <see cref="Result"/> instance is in a successful state.</param>
@@ -424,6 +456,38 @@ public abstract class Result<T> : IValueEquatable<Result<T>>, IDisposable, IAsyn
     /// </summary>
     /// <returns>Returns a hash code for the current instance.</returns>
     public override int GetHashCode() => default;
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or <see langword="null"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public abstract Exception? GetExceptionOrDefault();
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <param name="defaultException">The default exception to return in the event that the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</param>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure"/> state,
+    /// or the specified default exception if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    public abstract Exception GetExceptionOrDefault(Exception defaultException);
+
+    /// <summary>
+    /// Gets the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </summary>
+    /// <returns>
+    /// Returns the underlying exception if the current <see cref="Result{T}"/> is in a <see cref="Failure{T}"/> state,
+    /// or throws <see cref="InvalidOperationException"/> if the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">If the current <see cref="Result{T}"/> is in a <see cref="Success{T}"/> state.</exception>
+    public abstract Exception GetExceptionOrThrow();
 
     /// <summary>
     /// Gets the underlying value of the current <see cref="Result{T}"/> instance, if the underlying value is present;

--- a/OnixLabs.Numerics/OnixLabs.Numerics.csproj
+++ b/OnixLabs.Numerics/OnixLabs.Numerics.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Numerics</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Numerics API for .NET</Description>
-        <AssemblyVersion>8.14.0</AssemblyVersion>
+        <AssemblyVersion>8.15.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.14.0</PackageVersion>
+        <PackageVersion>8.15.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
+++ b/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security.Cryptography</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Cryptography API for .NET</Description>
-        <AssemblyVersion>8.14.0</AssemblyVersion>
+        <AssemblyVersion>8.15.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.14.0</PackageVersion>
+        <PackageVersion>8.15.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security/OnixLabs.Security.csproj
+++ b/OnixLabs.Security/OnixLabs.Security.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Security API for .NET</Description>
-        <AssemblyVersion>8.14.0</AssemblyVersion>
+        <AssemblyVersion>8.15.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.14.0</PackageVersion>
+        <PackageVersion>8.15.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Added methods to `Result` and `Result<T>` for obtaining underlying exceptions, and methods to `Failure` and `Failure<T>` to allow casting to other `Result` and `Result<T>` types. This also includes overloads for async programming.