### PR TITLE
feature/readonlysequence-constructors

### DIFF
--- a/OnixLabs.Core.UnitTests.Data/BufferSegment.cs
+++ b/OnixLabs.Core.UnitTests.Data/BufferSegment.cs
@@ -1,0 +1,42 @@
+// Copyright 2020 ONIXLabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Buffers;
+
+namespace OnixLabs.Core.UnitTests.Data;
+
+public sealed class BufferSegment<T> : ReadOnlySequenceSegment<T>
+{
+    private BufferSegment(ReadOnlyMemory<T> memory) => Memory = memory;
+
+    private void SetNext(BufferSegment<T> next)
+    {
+        Next = next;
+        next.RunningIndex = RunningIndex + Memory.Length;
+    }
+
+    public static ReadOnlySequence<T> FromMemory(ReadOnlyMemory<T>[] segments)
+    {
+        if (segments.Length == 1)
+            return new ReadOnlySequence<T>(segments[0]);
+
+        BufferSegment<T>[] bufferSegments = segments
+            .Select(segment => new BufferSegment<T>(segment)).ToArray();
+
+        for (int index = 0; index < bufferSegments.Length - 1; index++)
+            bufferSegments[index].SetNext(bufferSegments[index + 1]);
+
+        return new ReadOnlySequence<T>(bufferSegments[0], 0, bufferSegments[^1], bufferSegments[^1].Memory.Length);
+    }
+}

--- a/OnixLabs.Core.UnitTests/PreconditionTests.cs
+++ b/OnixLabs.Core.UnitTests/PreconditionTests.cs
@@ -54,6 +54,34 @@ public sealed class PreconditionTests
         CheckNotNull(new object());
     }
 
+    [Fact(DisplayName = "CheckNotNull of ValueType should throw an InvalidOperationException when the condition is null")]
+    public void CheckNotNullOfValueTypeShouldThrowInvalidOperationExceptionWhenConditionIsNull()
+    {
+        // Given
+        int? expected = null;
+        int actual = default;
+
+        // When
+        Exception exception = Assert.Throws<InvalidOperationException>(() => actual = CheckNotNull(expected));
+
+        // Then
+        Assert.Equal(default, actual);
+        Assert.Equal("Argument must not be null.", exception.Message);
+    }
+
+    [Fact(DisplayName = "CheckNotNull of ValueType should not throw an InvalidOperationException when the condition is not null")]
+    public void CheckNotNullOfValueTypeShouldNotThrowInvalidOperationExceptionWhenConditionIsNotNull()
+    {
+        // Given
+        int? expected = 123;
+
+        // When
+        int actual = CheckNotNull(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "CheckNotNullOrEmpty should throw an InvalidOperationException when the value is null")]
     public void CheckNotNullOrEmptyShouldThrowInvalidOperationExceptionWhenValueIsNull()
     {
@@ -238,6 +266,34 @@ public sealed class PreconditionTests
     {
         // Given / When / Then
         RequireNotNull(new object());
+    }
+
+    [Fact(DisplayName = "RequireNotNull of ValueType should throw an InvalidOperationException when the condition is null")]
+    public void RequireNotNullOfValueTypeShouldThrowInvalidOperationExceptionWhenConditionIsNull()
+    {
+        // Given
+        int? expected = null;
+        int actual = default;
+
+        // When
+        Exception exception = Assert.Throws<ArgumentNullException>(() => actual = RequireNotNull(expected));
+
+        // Then
+        Assert.Equal(default, actual);
+        Assert.Equal("Argument must not be null.", exception.Message);
+    }
+
+    [Fact(DisplayName = "RequireNotNull of ValueType should not throw an InvalidOperationException when the condition is not null")]
+    public void RequireNotNullOfValueTypeShouldNotThrowInvalidOperationExceptionWhenConditionIsNotNull()
+    {
+        // Given
+        int? expected = 123;
+
+        // When
+        int actual = RequireNotNull(expected);
+
+        // Then
+        Assert.Equal(expected, actual);
     }
 
     [Fact(DisplayName = "RequireNotNullOrEmpty should throw an ArgumentException when the value is null")]

--- a/OnixLabs.Core.UnitTests/ReadOnlySequenceExtensionTests.cs
+++ b/OnixLabs.Core.UnitTests/ReadOnlySequenceExtensionTests.cs
@@ -1,0 +1,54 @@
+// Copyright 2020 ONIXLabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Buffers;
+using OnixLabs.Core.UnitTests.Data;
+using Xunit;
+
+namespace OnixLabs.Core.UnitTests;
+
+public sealed class ReadOnlySequenceExtensionTests
+{
+    [Fact(DisplayName = "ReadOnlySequence.CopyTo should copy into a new array with a single element")]
+    public void ReadOnlySequenceCopyToShouldCopyIntoNewArrayWithSingleElement()
+    {
+        // Given
+        string[] expected = ["ABC", "XYZ", "123", "789"];
+        ReadOnlySequence<string> value = new(expected);
+
+        // When
+        value.CopyTo(out string[] actual);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(DisplayName = "ReadOnlySequence.CopyTo should copy into a new array with multiple elements")]
+    public void ReadOnlySequenceCopyToShouldCopyIntoNewArrayWithMultipleElements()
+    {
+        // Given
+        string[] expected = ["ABC", "XYZ", "123", "789"];
+        ReadOnlySequence<string> value = BufferSegment<string>.FromMemory([
+            new ReadOnlyMemory<string>(["ABC", "XYZ"]),
+            new ReadOnlyMemory<string>(["123", "789"])
+        ]);
+
+        // When
+        value.CopyTo(out string[] actual);
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+}

--- a/OnixLabs.Core.UnitTests/Text/Base16Tests.cs
+++ b/OnixLabs.Core.UnitTests/Text/Base16Tests.cs
@@ -97,6 +97,21 @@ public sealed class Base16Tests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Base16 should be implicitly constructable from ReadOnlySequence<byte>")]
+    public void Base16ShouldBeImplicitlyConstructableFromReadOnlySequenceOfByte()
+    {
+        // Given
+        byte[] expected = [1, 2, 3, 4];
+        ReadOnlySequence<byte> value = new(expected);
+
+        // When
+        Base16 candidate = value;
+        byte[] actual = candidate.ToByteArray();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Base16 should not change when modifying the original byte array")]
     public void Base16ShouldNotChangeWhenModifyingOriginalByteArray()
     {

--- a/OnixLabs.Core.UnitTests/Text/Base32Tests.cs
+++ b/OnixLabs.Core.UnitTests/Text/Base32Tests.cs
@@ -97,6 +97,21 @@ public sealed class Base32Tests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Base32 should be implicitly constructable from ReadOnlySequence<byte>")]
+    public void Base32ShouldBeImplicitlyConstructableFromReadOnlySequenceOfByte()
+    {
+        // Given
+        byte[] expected = [1, 2, 3, 4];
+        ReadOnlySequence<byte> value = new(expected);
+
+        // When
+        Base32 candidate = value;
+        byte[] actual = candidate.ToByteArray();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Base32 should not change when modifying the original byte array")]
     public void Base32ShouldNotChangeWhenModifyingOriginalByteArray()
     {

--- a/OnixLabs.Core.UnitTests/Text/Base58Tests.cs
+++ b/OnixLabs.Core.UnitTests/Text/Base58Tests.cs
@@ -52,6 +52,21 @@ public sealed class Base58Tests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Base58 should be implicitly constructable from ReadOnlySequence<byte>")]
+    public void Base58ShouldBeImplicitlyConstructableFromReadOnlySequenceOfByte()
+    {
+        // Given
+        byte[] expected = [1, 2, 3, 4];
+        ReadOnlySequence<byte> value = new(expected);
+
+        // When
+        Base58 candidate = value;
+        byte[] actual = candidate.ToByteArray();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Base58 should be implicitly constructable from string")]
     public void Base58ShouldBeImplicitlyConstructableFromString()
     {

--- a/OnixLabs.Core.UnitTests/Text/Base64Tests.cs
+++ b/OnixLabs.Core.UnitTests/Text/Base64Tests.cs
@@ -97,6 +97,21 @@ public sealed class Base64Tests
         Assert.Equal(expected, actual);
     }
 
+    [Fact(DisplayName = "Base64 should be implicitly constructable from ReadOnlySequence<byte>")]
+    public void Base64ShouldBeImplicitlyConstructableFromReadOnlySequenceOfByte()
+    {
+        // Given
+        byte[] expected = [1, 2, 3, 4];
+        ReadOnlySequence<byte> value = new(expected);
+
+        // When
+        Base64 candidate = value;
+        byte[] actual = candidate.ToByteArray();
+
+        // Then
+        Assert.Equal(expected, actual);
+    }
+
     [Fact(DisplayName = "Base64 should not change when modifying the original byte array")]
     public void Base64ShouldNotChangeWhenModifyingOriginalByteArray()
     {

--- a/OnixLabs.Core/Extensions.ReadOnlySequence.cs
+++ b/OnixLabs.Core/Extensions.ReadOnlySequence.cs
@@ -1,0 +1,44 @@
+// Copyright 2020 ONIXLabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Buffers;
+using System.ComponentModel;
+
+namespace OnixLabs.Core;
+
+/// <summary>
+/// Provides extension methods for read-only sequences.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class ReadOnlySequenceExtensions
+{
+    /// <summary>
+    /// Copies the current <see cref="ReadOnlySequence{T}"/> to the specified <see cref="T:[]"/> by reference.
+    /// </summary>
+    /// <param name="sequence">The current <see cref="ReadOnlySequence{T}"/> to copy.</param>
+    /// <param name="array">The <see cref="T:[]"/> to copy to.</param>
+    /// <typeparam name="T">The underlying type of the specified <see cref="ReadOnlySequence{T}"/> and <see cref="T:[]"/>.</typeparam>
+    public static void CopyTo<T>(this ReadOnlySequence<T> sequence, out T[] array)
+    {
+        if (sequence.IsSingleSegment)
+        {
+            array = sequence.First.Span.ToArray();
+        }
+        else
+        {
+            array = new T[sequence.Length];
+            sequence.CopyTo(array);
+        }
+    }
+}

--- a/OnixLabs.Core/Extensions.String.cs
+++ b/OnixLabs.Core/Extensions.String.cs
@@ -43,11 +43,6 @@ public static class StringExtensions
     private const DateTimeStyles DefaultStyles = DateTimeStyles.None;
 
     /// <summary>
-    /// The default encoding.
-    /// </summary>
-    private static readonly Encoding DefaultEncoding = Encoding.UTF8;
-
-    /// <summary>
     /// Repeats the current <see cref="String"/> by the specified number of repetitions.
     /// </summary>
     /// <param name="value">The <see cref="String"/> instance to repeat.</param>
@@ -246,7 +241,7 @@ public static class StringExtensions
     /// <param name="value">The current <see cref="String"/> from which to obtain a <see cref="T:Byte[]"/>.</param>
     /// <param name="encoding">The encoding that will be used to convert the current <see cref="String"/> into a <see cref="T:Byte[]"/>.</param>
     /// <returns>Returns a new <see cref="T:Byte[]"/> representation of the current <see cref="String"/> instance.</returns>
-    public static byte[] ToByteArray(this string value, Encoding? encoding = null) => (encoding ?? DefaultEncoding).GetBytes(value);
+    public static byte[] ToByteArray(this string value, Encoding? encoding = null) => encoding.GetOrDefault().GetBytes(value);
 
     /// <summary>
     /// Converts the current <see cref="String"/> instance into a new <see cref="DateTime"/> instance.

--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -45,4 +45,9 @@
     <ItemGroup>
         <Using Include="OnixLabs.Core.Preconditions" Static="True"/>
     </ItemGroup>
+    <ItemGroup>
+        <InternalsVisibleTo Include="OnixLabs.Numerics"/>
+        <InternalsVisibleTo Include="OnixLabs.Security"/>
+        <InternalsVisibleTo Include="OnixLabs.Security.Cryptography"/>
+    </ItemGroup>
 </Project>

--- a/OnixLabs.Core/OnixLabs.Core.csproj
+++ b/OnixLabs.Core/OnixLabs.Core.csproj
@@ -7,11 +7,11 @@
         <Title>OnixLabs.Core</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Core API for .NET</Description>
-        <AssemblyVersion>8.15.0</AssemblyVersion>
+        <AssemblyVersion>8.16.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.15.0</PackageVersion>
+        <PackageVersion>8.16.0</PackageVersion>
     </PropertyGroup>
     <PropertyGroup>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/OnixLabs.Core/Preconditions.cs
+++ b/OnixLabs.Core/Preconditions.cs
@@ -54,6 +54,19 @@ public static class Preconditions
     }
 
     /// <summary>
+    /// Performs a general pre-condition check that fails if the specified value is <see langword="null"/>.
+    /// </summary>
+    /// <param name="value">The nullable value to check.</param>
+    /// <param name="message">The exception message to throw in the event that the specified value is <see langword="null"/>.</param>
+    /// <typeparam name="T">The underlying type of the value.</typeparam>
+    /// <returns>Returns a non-null value of the specified type.</returns>
+    /// <exception cref="InvalidOperationException">If the specified value is <see langword="null"/>.</exception>
+    public static T CheckNotNull<T>(T? value, string message = ArgumentNull) where T : struct
+    {
+        return value ?? throw new InvalidOperationException(message);
+    }
+
+    /// <summary>
     /// Performs a general pre-condition check that fails if the specified value is <see langword="null"/> or an empty string.
     /// </summary>
     /// <param name="value">The <see cref="String"/> value to check.</param>
@@ -99,6 +112,7 @@ public static class Preconditions
     /// <param name="parameterName">The name of the invalid parameter.</param>
     /// <exception cref="ArgumentOutOfRangeException">If the specified condition is <see langword="false"/>.</exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This method is obsolete and will be removed in a future version. Use RequireWithinRangeInclusive or RequireWithinRangeExclusive methods instead.")]
     public static void RequireWithinRange(bool condition, string message = ArgumentOutOfRange, string? parameterName = null)
     {
         if (!condition) throw new ArgumentOutOfRangeException(parameterName, message);
@@ -144,6 +158,20 @@ public static class Preconditions
     /// <returns>Returns a non-null value of the specified type.</returns>
     /// <exception cref="ArgumentNullException">If the specified value is <see langword="null"/>.</exception>
     public static T RequireNotNull<T>(T? value, string message = ArgumentNull, string? parameterName = null)
+    {
+        return value ?? throw new ArgumentNullException(parameterName, message);
+    }
+
+    /// <summary>
+    /// Performs a general pre-condition requirement that fails if the specified value is <see langword="null"/>.
+    /// </summary>
+    /// <param name="value">The nullable value to check.</param>
+    /// <param name="message">The exception message to throw in the event that the specified value is <see langword="null"/>.</param>
+    /// <param name="parameterName">The name of the invalid parameter.</param>
+    /// <typeparam name="T">The underlying type of the value.</typeparam>
+    /// <returns>Returns a non-null value of the specified type.</returns>
+    /// <exception cref="ArgumentNullException">If the specified value is <see langword="null"/>.</exception>
+    public static T RequireNotNull<T>(T? value, string message = ArgumentNull, string? parameterName = null) where T : struct
     {
         return value ?? throw new ArgumentNullException(parameterName, message);
     }

--- a/OnixLabs.Core/Text/Base16.Convertible.cs
+++ b/OnixLabs.Core/Text/Base16.Convertible.cs
@@ -31,8 +31,15 @@ public readonly partial struct Base16
     /// Create a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base16"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Base16(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="Base16"/> instance.</param>
+    /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base16(ReadOnlySequence<byte> value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base16"/> instance from the specified <see cref="string"/> value.
@@ -40,7 +47,7 @@ public readonly partial struct Base16
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base16"/> instance.</param>
     /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="string"/> value.</returns>
-    public static implicit operator Base16(string value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base16(string value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base16"/> instance from the specified <see cref="T:char[]"/> value.
@@ -48,13 +55,13 @@ public readonly partial struct Base16
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base16"/> instance.</param>
     /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="T:char[]"/> value.</returns>
-    public static implicit operator Base16(char[] value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base16(char[] value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
-    /// <remarks>The <see cref="ReadOnlySequence{Char}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
+    /// <remarks>The <see cref="ReadOnlySequence{T}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base16"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySequence{Char}"/> value.</returns>
-    public static implicit operator Base16(ReadOnlySequence<char> value) => new(Encoding.UTF8.GetBytes(value));
+    /// <returns>Returns a new <see cref="Base16"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base16(ReadOnlySequence<char> value) => new(value);
 }

--- a/OnixLabs.Core/Text/Base16.cs
+++ b/OnixLabs.Core/Text/Base16.cs
@@ -13,14 +13,49 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
+using System.Text;
 
 namespace OnixLabs.Core.Text;
 
 /// <summary>
 /// Represents a Base-16 value.
 /// </summary>
-/// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
+/// <param name="value">The <see cref="ReadOnlySpan{T}"/> with which to initialize the <see cref="Base16"/> instance.</param>
 public readonly partial struct Base16(ReadOnlySpan<byte> value) : IBaseValue<Base16>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base16"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base16"/> instance.</param>
+    public Base16(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base16"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> with which to initialize the <see cref="Base16"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base16(string value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base16"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="T:char[]"/> with which to initialize the <see cref="Base16"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base16(char[] value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base16"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base16"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base16(ReadOnlySequence<char> value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
     private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Core/Text/Base32.Convertible.cs
+++ b/OnixLabs.Core/Text/Base32.Convertible.cs
@@ -31,8 +31,15 @@ public readonly partial struct Base32
     /// Create a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base32"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Base32(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="Base32"/> instance.</param>
+    /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base32(ReadOnlySequence<byte> value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base32"/> instance from the specified <see cref="string"/> value.
@@ -40,7 +47,7 @@ public readonly partial struct Base32
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base32"/> instance.</param>
     /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="string"/> value.</returns>
-    public static implicit operator Base32(string value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base32(string value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base32"/> instance from the specified <see cref="T:char[]"/> value.
@@ -48,13 +55,13 @@ public readonly partial struct Base32
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base32"/> instance.</param>
     /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="T:char[]"/> value.</returns>
-    public static implicit operator Base32(char[] value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base32(char[] value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
-    /// <remarks>The <see cref="ReadOnlySequence{Char}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
+    /// <remarks>The <see cref="ReadOnlySequence{T}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base32"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySequence{Char}"/> value.</returns>
-    public static implicit operator Base32(ReadOnlySequence<char> value) => new(Encoding.UTF8.GetBytes(value));
+    /// <returns>Returns a new <see cref="Base32"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base32(ReadOnlySequence<char> value) => new(value);
 }

--- a/OnixLabs.Core/Text/Base32.cs
+++ b/OnixLabs.Core/Text/Base32.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
+using System.Text;
 
 namespace OnixLabs.Core.Text;
 
@@ -22,5 +24,38 @@ namespace OnixLabs.Core.Text;
 /// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
 public readonly partial struct Base32(ReadOnlySpan<byte> value) : IBaseValue<Base32>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base32"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base32"/> instance.</param>
+    public Base32(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base32"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> with which to initialize the <see cref="Base32"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base32(string value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base32"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="T:char[]"/> with which to initialize the <see cref="Base32"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base32(char[] value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base32"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base32"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base32(ReadOnlySequence<char> value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
     private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Core/Text/Base32.cs
+++ b/OnixLabs.Core/Text/Base32.cs
@@ -21,7 +21,7 @@ namespace OnixLabs.Core.Text;
 /// <summary>
 /// Represents a Base-32 value.
 /// </summary>
-/// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
+/// <param name="value">The <see cref="ReadOnlySpan{T}"/> with which to initialize the <see cref="Base32"/> instance.</param>
 public readonly partial struct Base32(ReadOnlySpan<byte> value) : IBaseValue<Base32>
 {
     /// <summary>

--- a/OnixLabs.Core/Text/Base58.Convertible.cs
+++ b/OnixLabs.Core/Text/Base58.Convertible.cs
@@ -31,8 +31,15 @@ public readonly partial struct Base58
     /// Create a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base58"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Base58(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="Base58"/> instance.</param>
+    /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base58(ReadOnlySequence<byte> value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base58"/> instance from the specified <see cref="string"/> value.
@@ -40,7 +47,7 @@ public readonly partial struct Base58
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base58"/> instance.</param>
     /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="string"/> value.</returns>
-    public static implicit operator Base58(string value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base58(string value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base58"/> instance from the specified <see cref="T:char[]"/> value.
@@ -48,13 +55,13 @@ public readonly partial struct Base58
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base58"/> instance.</param>
     /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="T:char[]"/> value.</returns>
-    public static implicit operator Base58(char[] value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base58(char[] value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
-    /// <remarks>The <see cref="ReadOnlySequence{Char}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
+    /// <remarks>The <see cref="ReadOnlySequence{T}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base58"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySequence{Char}"/> value.</returns>
-    public static implicit operator Base58(ReadOnlySequence<char> value) => new(Encoding.UTF8.GetBytes(value));
+    /// <returns>Returns a new <see cref="Base58"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base58(ReadOnlySequence<char> value) => new(value);
 }

--- a/OnixLabs.Core/Text/Base58.cs
+++ b/OnixLabs.Core/Text/Base58.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
+using System.Text;
 
 namespace OnixLabs.Core.Text;
 
@@ -22,5 +24,38 @@ namespace OnixLabs.Core.Text;
 /// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
 public readonly partial struct Base58(ReadOnlySpan<byte> value) : IBaseValue<Base58>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base58"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base58"/> instance.</param>
+    public Base58(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base58"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> with which to initialize the <see cref="Base58"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base58(string value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base58"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="T:char[]"/> with which to initialize the <see cref="Base58"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base58(char[] value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base58"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base58"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base58(ReadOnlySequence<char> value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
     private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Core/Text/Base58.cs
+++ b/OnixLabs.Core/Text/Base58.cs
@@ -21,7 +21,7 @@ namespace OnixLabs.Core.Text;
 /// <summary>
 /// Represents a Base-58 value.
 /// </summary>
-/// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
+/// <param name="value">The <see cref="ReadOnlySpan{T}"/> with which to initialize the <see cref="Base58"/> instance.</param>
 public readonly partial struct Base58(ReadOnlySpan<byte> value) : IBaseValue<Base58>
 {
     /// <summary>

--- a/OnixLabs.Core/Text/Base64.Convertible.cs
+++ b/OnixLabs.Core/Text/Base64.Convertible.cs
@@ -31,8 +31,15 @@ public readonly partial struct Base64
     /// Create a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base64"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Base64(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="Base64"/> instance.</param>
+    /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base64(ReadOnlySequence<byte> value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base64"/> instance from the specified <see cref="string"/> value.
@@ -40,7 +47,7 @@ public readonly partial struct Base64
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base64"/> instance.</param>
     /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="string"/> value.</returns>
-    public static implicit operator Base64(string value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base64(string value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base64"/> instance from the specified <see cref="T:char[]"/> value.
@@ -48,13 +55,13 @@ public readonly partial struct Base64
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base64"/> instance.</param>
     /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="T:char[]"/> value.</returns>
-    public static implicit operator Base64(char[] value) => new(Encoding.UTF8.GetBytes(value));
+    public static implicit operator Base64(char[] value) => new(value);
 
     /// <summary>
     /// Create a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
-    /// <remarks>The <see cref="ReadOnlySequence{Char}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
+    /// <remarks>The <see cref="ReadOnlySequence{T}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Base64"/> instance.</param>
-    /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySequence{Char}"/> value.</returns>
-    public static implicit operator Base64(ReadOnlySequence<char> value) => new(Encoding.UTF8.GetBytes(value));
+    /// <returns>Returns a new <see cref="Base64"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Base64(ReadOnlySequence<char> value) => new(value);
 }

--- a/OnixLabs.Core/Text/Base64.cs
+++ b/OnixLabs.Core/Text/Base64.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
+using System.Text;
 
 namespace OnixLabs.Core.Text;
 
@@ -22,5 +24,38 @@ namespace OnixLabs.Core.Text;
 /// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
 public readonly partial struct Base64(ReadOnlySpan<byte> value) : IBaseValue<Base64>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base64"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base64"/> instance.</param>
+    public Base64(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base64"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> with which to initialize the <see cref="Base64"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base64(string value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base64"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="T:char[]"/> with which to initialize the <see cref="Base64"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base64(char[] value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Base64"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Base64"/> instance.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to obtain the underlying value.</param>
+    public Base64(ReadOnlySequence<char> value, Encoding? encoding = null) : this(encoding.GetOrDefault().GetBytes(value))
+    {
+    }
+
     private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Core/Text/Base64.cs
+++ b/OnixLabs.Core/Text/Base64.cs
@@ -21,7 +21,7 @@ namespace OnixLabs.Core.Text;
 /// <summary>
 /// Represents a Base-64 value.
 /// </summary>
-/// <param name="value">The underlying <see cref="T:Byte[]"/> value.</param>
+/// <param name="value">The <see cref="ReadOnlySpan{T}"/> with which to initialize the <see cref="Base64"/> instance.</param>
 public readonly partial struct Base64(ReadOnlySpan<byte> value) : IBaseValue<Base64>
 {
     /// <summary>

--- a/OnixLabs.Core/Text/Extensions.Encoding.cs
+++ b/OnixLabs.Core/Text/Extensions.Encoding.cs
@@ -1,0 +1,37 @@
+// Copyright 2020 ONIXLabs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.ComponentModel;
+using System.Text;
+
+namespace OnixLabs.Core.Text;
+
+/// <summary>
+/// Provides extension methods for text encodings.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class EncodingExtensions
+{
+    /// <summary>
+    /// The default encoding, which is <see cref="Encoding.UTF8"/>.
+    /// </summary>
+    private static readonly Encoding Default = Encoding.UTF8;
+
+    /// <summary>
+    /// Gets the current <see cref="Encoding"/>, or the default encoding if the current <see cref="Encoding"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="encoding">The current <see cref="Encoding"/>.</param>
+    /// <returns>Returns the current <see cref="Encoding"/>, or the default encoding if the current <see cref="Encoding"/> is <see langword="null"/>.</returns>
+    public static Encoding GetOrDefault(this Encoding? encoding) => encoding ?? Default;
+}

--- a/OnixLabs.Core/Text/Extensions.cs
+++ b/OnixLabs.Core/Text/Extensions.cs
@@ -53,30 +53,30 @@ public static class Extensions
     public static Base64 ToBase64(this byte[] value) => new(value);
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Base16"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Base16"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Base16"/> instance.</returns>
     public static Base16 ToBase16(this ReadOnlySpan<byte> value) => new(value);
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Base32"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Base32"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Base32"/> instance.</returns>
     public static Base32 ToBase32(this ReadOnlySpan<byte> value) => new(value);
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Base58"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Base58"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Base58"/> instance.</returns>
     public static Base58 ToBase58(this ReadOnlySpan<byte> value) => new(value);
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Base64"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Base64"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Base64"/> instance.</returns>
     public static Base64 ToBase64(this ReadOnlySpan<byte> value) => new(value);
 }

--- a/OnixLabs.Core/Text/IBaseCodec.cs
+++ b/OnixLabs.Core/Text/IBaseCodec.cs
@@ -53,15 +53,15 @@ public interface IBaseCodec
     public static Base64Codec Base64 => new();
 
     /// <summary>
-    /// Obtains a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{Byte}"/> value.
+    /// Obtains a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value to convert.</param>
     /// <param name="provider">
     /// The <see cref="IFormatProvider"/> which will be used to obtain the base representation.
     /// <remarks> Allowed values for this parameter are <see cref="Base16FormatProvider"/>, <see cref="Base32FormatProvider"/>, <see cref="Base58FormatProvider"/>, and <see cref="Base64FormatProvider"/>.</remarks>
     /// </param>
-    /// <returns>Returns a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{Byte}"/> value.</returns>
-    /// <exception cref="FormatException">If the specified <see cref="ReadOnlySpan{Byte}"/> value cannot be converted.</exception>
+    /// <returns>Returns a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
+    /// <exception cref="FormatException">If the specified <see cref="ReadOnlySpan{T}"/> value cannot be converted.</exception>
     public static string GetString(ReadOnlySpan<byte> value, IFormatProvider provider)
     {
         if (TryGetString(value, provider, out string result)) return result;
@@ -69,15 +69,15 @@ public interface IBaseCodec
     }
 
     /// <summary>
-    /// Obtains a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{Char}"/> value.
+    /// Obtains a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value to convert.</param>
     /// <param name="provider">
-    /// The <see cref="IFormatProvider"/> which will be used to convert the specified <see cref="ReadOnlySpan{Char}"/> value.
+    /// The <see cref="IFormatProvider"/> which will be used to convert the specified <see cref="ReadOnlySpan{T}"/> value.
     /// <remarks> Allowed values for this parameter are <see cref="Base16FormatProvider"/>, <see cref="Base32FormatProvider"/>, <see cref="Base58FormatProvider"/>, and <see cref="Base64FormatProvider"/>.</remarks>
     /// </param>
-    /// <returns>Returns a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
-    /// <exception cref="FormatException">If the specified <see cref="ReadOnlySpan{Char}"/> value cannot be converted.</exception>
+    /// <returns>Returns a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
+    /// <exception cref="FormatException">If the specified <see cref="ReadOnlySpan{T}"/> value cannot be converted.</exception>
     public static byte[] GetBytes(ReadOnlySpan<char> value, IFormatProvider provider)
     {
         if (TryGetBytes(value, provider, out byte[] result)) return result;
@@ -85,14 +85,14 @@ public interface IBaseCodec
     }
 
     /// <summary>
-    /// Tries to obtain a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{Byte}"/> value.
+    /// Tries to obtain a base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value to convert.</param>
     /// <param name="provider">
     /// The <see cref="IFormatProvider"/> which will be used to obtain the base representation.
     /// <remarks> Allowed values for this parameter are <see cref="Base16FormatProvider"/>, <see cref="Base32FormatProvider"/>, <see cref="Base58FormatProvider"/>, and <see cref="Base64FormatProvider"/>.</remarks>
     /// </param>
-    /// <param name="result"> A base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{Byte}"/> value, or an empty string if the value cannot be converted.</param>
+    /// <param name="result"> A base <see cref="string"/> representation of the specified <see cref="ReadOnlySpan{T}"/> value, or an empty string if the value cannot be converted.</param>
     /// <returns>Returns <see langword="true"/> if the conversion was successful; otherwise, <see langword="false"/>.</returns>
     public static bool TryGetString(ReadOnlySpan<byte> value, IFormatProvider provider, out string result)
     {
@@ -109,14 +109,14 @@ public interface IBaseCodec
     }
 
     /// <summary>
-    /// Tries to obtain a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{Char}"/> value.
+    /// Tries to obtain a new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value to convert.</param>
     /// <param name="provider">
-    /// The <see cref="IFormatProvider"/> which will be used to convert the specified <see cref="ReadOnlySpan{Char}"/> value.
+    /// The <see cref="IFormatProvider"/> which will be used to convert the specified <see cref="ReadOnlySpan{T}"/> value.
     /// <remarks> Allowed values for this parameter are <see cref="Base16FormatProvider"/>, <see cref="Base32FormatProvider"/>, <see cref="Base58FormatProvider"/>, and <see cref="Base64FormatProvider"/>.</remarks>
     /// </param>
-    /// <param name="result">A new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{Char}"/> value, or an empty <see cref="T:byte[]"/> array if the value cannot be converted.</param>
+    /// <param name="result">A new <see cref="T:byte[]"/> array by converting the specified <see cref="ReadOnlySpan{T}"/> value, or an empty <see cref="T:byte[]"/> array if the value cannot be converted.</param>
     /// <returns>Returns <see langword="true"/> if the conversion was successful; otherwise, <see langword="false"/>.</returns>
     public static bool TryGetBytes(ReadOnlySpan<char> value, IFormatProvider provider, out byte[] result)
     {

--- a/OnixLabs.Numerics/OnixLabs.Numerics.csproj
+++ b/OnixLabs.Numerics/OnixLabs.Numerics.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Numerics</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Numerics API for .NET</Description>
-        <AssemblyVersion>8.15.0</AssemblyVersion>
+        <AssemblyVersion>8.16.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.15.0</PackageVersion>
+        <PackageVersion>8.16.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Playground/Program.cs
+++ b/OnixLabs.Playground/Program.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace OnixLabs.Playground;
 
 internal static class Program
@@ -22,4 +20,3 @@ internal static class Program
     {
     }
 }
-

--- a/OnixLabs.Playground/Program.cs
+++ b/OnixLabs.Playground/Program.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace OnixLabs.Playground;
 
 internal static class Program
@@ -20,3 +22,4 @@ internal static class Program
     {
     }
 }
+

--- a/OnixLabs.Security.Cryptography.UnitTests.Data/TestPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography.UnitTests.Data/TestPrivateKey.cs
@@ -14,4 +14,7 @@
 
 namespace OnixLabs.Security.Cryptography.UnitTests.Data;
 
-public sealed class TestPrivateKey(ReadOnlySpan<byte> value) : PrivateKey(value);
+public sealed class TestPrivateKey(ReadOnlySpan<byte> value) : PrivateKey(value)
+{
+    public override NamedPrivateKey ToNamedPrivateKey() => new(this, "TEST");
+}

--- a/OnixLabs.Security.Cryptography.UnitTests.Data/TestPublicKey.cs
+++ b/OnixLabs.Security.Cryptography.UnitTests.Data/TestPublicKey.cs
@@ -14,4 +14,7 @@
 
 namespace OnixLabs.Security.Cryptography.UnitTests.Data;
 
-public sealed class TestPublicKey(ReadOnlySpan<byte> value) : PublicKey(value);
+public sealed class TestPublicKey(ReadOnlySpan<byte> value) : PublicKey(value)
+{
+    public override NamedPublicKey ToNamedPublicKey() => new(this, "TEST");
+}

--- a/OnixLabs.Security.Cryptography/DigitalSignature.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/DigitalSignature.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public readonly partial struct DigitalSignature
     /// Create a new <see cref="DigitalSignature"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="DigitalSignature"/> instance.</param>
-    /// <returns>Returns a new <see cref="DigitalSignature"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="DigitalSignature"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator DigitalSignature(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="DigitalSignature"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="DigitalSignature"/> instance.</param>
+    /// <returns>Returns a new <see cref="DigitalSignature"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator DigitalSignature(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/DigitalSignature.Parse.cs
+++ b/OnixLabs.Security.Cryptography/DigitalSignature.Parse.cs
@@ -28,11 +28,11 @@ public readonly partial struct DigitalSignature
     public static DigitalSignature Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="DigitalSignature"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="DigitalSignature"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="DigitalSignature"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="DigitalSignature"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static DigitalSignature Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out DigitalSignature result)) return result;
@@ -52,13 +52,13 @@ public readonly partial struct DigitalSignature
     public static bool TryParse(string? value, IFormatProvider? provider, out DigitalSignature result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="DigitalSignature"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="DigitalSignature"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="DigitalSignature"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="DigitalSignature"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="DigitalSignature"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="DigitalSignature"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out DigitalSignature result)

--- a/OnixLabs.Security.Cryptography/DigitalSignature.cs
+++ b/OnixLabs.Security.Cryptography/DigitalSignature.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
+using OnixLabs.Core;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -22,5 +24,11 @@ namespace OnixLabs.Security.Cryptography;
 /// <param name="value">The underlying value of the cryptographic digital signature.</param>
 public readonly partial struct DigitalSignature(ReadOnlySpan<byte> value) : ICryptoPrimitive<DigitalSignature>, ISpanParsable<DigitalSignature>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DigitalSignature"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="DigitalSignature"/> instance.</param>
+    public DigitalSignature(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
+
     private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Security.Cryptography/EcdhPrivateKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPrivateKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class EcdhPrivateKey
     /// Create a new <see cref="EcdhPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="EcdhPrivateKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="EcdhPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdhPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator EcdhPrivateKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="EcdhPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="EcdhPrivateKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="EcdhPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator EcdhPrivateKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/EcdhPrivateKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPrivateKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class EcdhPrivateKey
     public static EcdhPrivateKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdhPrivateKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdhPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="EcdhPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdhPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static EcdhPrivateKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out EcdhPrivateKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class EcdhPrivateKey
     public static bool TryParse(string? value, IFormatProvider? provider, out EcdhPrivateKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdhPrivateKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdhPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="EcdhPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="EcdhPrivateKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="EcdhPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="EcdhPrivateKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out EcdhPrivateKey result)

--- a/OnixLabs.Security.Cryptography/EcdhPrivateKey.To.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPrivateKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class EcdhPrivateKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPrivateKey"/> from the current <see cref="EcdhPrivateKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPrivateKey"/> from the current <see cref="EcdhPrivateKey"/> instance.</returns>
+    public override NamedPrivateKey ToNamedPrivateKey() => new(this, "ECDH");
 }

--- a/OnixLabs.Security.Cryptography/EcdhPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPrivateKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -20,4 +21,13 @@ namespace OnixLabs.Security.Cryptography;
 /// Represents an EC Diffie-Hellman cryptographic private key.
 /// </summary>
 /// <param name="keyData">The underlying key data of the EC Diffie-Hellman cryptographic private key.</param>
-public sealed partial class EcdhPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IEcdhPrivateKey, ISpanParsable<EcdhPrivateKey>;
+public sealed partial class EcdhPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IEcdhPrivateKey, ISpanParsable<EcdhPrivateKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcdhPrivateKey"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="EcdhPrivateKey"/> instance.</param>
+    public EcdhPrivateKey(ReadOnlySequence<byte> value) : this(value.ToArray())
+    {
+    }
+}

--- a/OnixLabs.Security.Cryptography/EcdhPublicKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPublicKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class EcdhPublicKey
     /// Create a new <see cref="EcdhPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="EcdhPublicKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="EcdhPublicKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdhPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator EcdhPublicKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="EcdhPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="EcdhPublicKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="EcdhPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator EcdhPublicKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/EcdhPublicKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPublicKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class EcdhPublicKey
     public static EcdhPublicKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdhPublicKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdhPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="EcdhPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdhPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static EcdhPublicKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out EcdhPublicKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class EcdhPublicKey
     public static bool TryParse(string? value, IFormatProvider? provider, out EcdhPublicKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdhPublicKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdhPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="EcdhPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="EcdhPublicKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="EcdhPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="EcdhPublicKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out EcdhPublicKey result)

--- a/OnixLabs.Security.Cryptography/EcdhPublicKey.To.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPublicKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class EcdhPublicKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPublicKey"/> from the current <see cref="EcdhPublicKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPublicKey"/> from the current <see cref="EcdhPublicKey"/> instance.</returns>
+    public override NamedPublicKey ToNamedPublicKey() => new(this, "ECDH");
 }

--- a/OnixLabs.Security.Cryptography/EcdhPublicKey.cs
+++ b/OnixLabs.Security.Cryptography/EcdhPublicKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -20,4 +21,13 @@ namespace OnixLabs.Security.Cryptography;
 /// Represents an EC Diffie-Hellman cryptographic public key.
 /// </summary>
 /// <param name="keyData">The underlying key data of the EC Diffie-Hellman cryptographic public key.</param>
-public sealed partial class EcdhPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IEcdhPublicKey, ISpanParsable<EcdhPublicKey>;
+public sealed partial class EcdhPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IEcdhPublicKey, ISpanParsable<EcdhPublicKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcdhPublicKey"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="EcdhPublicKey"/> instance.</param>
+    public EcdhPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
+    {
+    }
+}

--- a/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class EcdsaPrivateKey
     /// Create a new <see cref="EcdsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="EcdsaPrivateKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="EcdsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator EcdsaPrivateKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="EcdsaPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="EcdsaPrivateKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="EcdsaPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator EcdsaPrivateKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class EcdsaPrivateKey
     public static EcdsaPrivateKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdsaPrivateKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdsaPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="EcdsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static EcdsaPrivateKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out EcdsaPrivateKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class EcdsaPrivateKey
     public static bool TryParse(string? value, IFormatProvider? provider, out EcdsaPrivateKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdsaPrivateKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdsaPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="EcdsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="EcdsaPrivateKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="EcdsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="EcdsaPrivateKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out EcdsaPrivateKey result)

--- a/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Sign.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPrivateKey.Sign.cs
@@ -22,7 +22,7 @@ namespace OnixLabs.Security.Cryptography;
 public sealed partial class EcdsaPrivateKey
 {
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -35,7 +35,7 @@ public sealed partial class EcdsaPrivateKey
     }
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -76,7 +76,7 @@ public sealed partial class EcdsaPrivateKey
     }
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -89,7 +89,7 @@ public sealed partial class EcdsaPrivateKey
     }
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -142,7 +142,7 @@ public sealed partial class EcdsaPrivateKey
     }
 
     /// <summary>
-    /// Signs the specified <see cref="ReadOnlySpan{Byte}"/>.
+    /// Signs the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="hash">The hash to sign.</param>
     /// <param name="format">The digital signature format which will be used to generate the cryptographic digital signature.</param>

--- a/OnixLabs.Security.Cryptography/EcdsaPrivateKey.To.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPrivateKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class EcdsaPrivateKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPrivateKey"/> from the current <see cref="EcdsaPrivateKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPrivateKey"/> from the current <see cref="EcdsaPrivateKey"/> instance.</returns>
+    public override NamedPrivateKey ToNamedPrivateKey() => new(this, "ECDSA");
 }

--- a/OnixLabs.Security.Cryptography/EcdsaPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPrivateKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -20,4 +21,13 @@ namespace OnixLabs.Security.Cryptography;
 /// Represents an ECDSA cryptographic private key.
 /// </summary>
 /// <param name="keyData">The underlying key data of the ECDSA cryptographic private key.</param>
-public sealed partial class EcdsaPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IEcdsaPrivateKey, ISpanParsable<EcdsaPrivateKey>;
+public sealed partial class EcdsaPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IEcdsaPrivateKey, ISpanParsable<EcdsaPrivateKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcdsaPrivateKey"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="EcdsaPrivateKey"/> instance.</param>
+    public EcdsaPrivateKey(ReadOnlySequence<byte> value) : this(value.ToArray())
+    {
+    }
+}

--- a/OnixLabs.Security.Cryptography/EcdsaPublicKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPublicKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class EcdsaPublicKey
     /// Create a new <see cref="EcdsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="EcdsaPublicKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="EcdsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator EcdsaPublicKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="EcdsaPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="EcdsaPublicKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="EcdsaPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator EcdsaPublicKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/EcdsaPublicKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPublicKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class EcdsaPublicKey
     public static EcdsaPublicKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdsaPublicKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdsaPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="EcdsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="EcdsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static EcdsaPublicKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out EcdsaPublicKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class EcdsaPublicKey
     public static bool TryParse(string? value, IFormatProvider? provider, out EcdsaPublicKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="EcdsaPublicKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="EcdsaPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="EcdsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="EcdsaPublicKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="EcdsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="EcdsaPublicKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out EcdsaPublicKey result)

--- a/OnixLabs.Security.Cryptography/EcdsaPublicKey.To.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPublicKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class EcdsaPublicKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPublicKey"/> from the current <see cref="EcdsaPublicKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPublicKey"/> from the current <see cref="EcdsaPublicKey"/> instance.</returns>
+    public override NamedPublicKey ToNamedPublicKey() => new(this, "ECDSA");
 }

--- a/OnixLabs.Security.Cryptography/EcdsaPublicKey.cs
+++ b/OnixLabs.Security.Cryptography/EcdsaPublicKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -20,4 +21,13 @@ namespace OnixLabs.Security.Cryptography;
 /// Represents an ECDSA cryptographic public key.
 /// </summary>
 /// <param name="keyData">The underlying key data of the ECDSA cryptographic public key.</param>
-public sealed partial class EcdsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IEcdsaPublicKey, ISpanParsable<EcdsaPublicKey>;
+public sealed partial class EcdsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IEcdsaPublicKey, ISpanParsable<EcdsaPublicKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EcdsaPublicKey"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="EcdsaPublicKey"/> instance.</param>
+    public EcdsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
+    {
+    }
+}

--- a/OnixLabs.Security.Cryptography/Extensions.HashAlgorithm.cs
+++ b/OnixLabs.Security.Cryptography/Extensions.HashAlgorithm.cs
@@ -20,6 +20,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using OnixLabs.Core;
+using OnixLabs.Core.Text;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -62,15 +63,15 @@ public static class HashAlgorithmExtensions
         algorithm.ComputeHash(data.Copy(offset, count), rounds);
 
     /// <summary>
-    /// Computes the hash value for the specified <see cref="ReadOnlySpan{Char}"/>.
+    /// Computes the hash value for the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="algorithm">The <see cref="HashAlgorithm"/> which will be used to compute a hash value.</param>
     /// <param name="data">The input data to compute the hash for.</param>
-    /// <param name="encoding">The <see cref="Encoding"/> which will be used to convert the specified <see cref="ReadOnlySpan{Char}"/>.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to convert the specified <see cref="ReadOnlySpan{T}"/>.</param>
     /// <param name="rounds">The number of rounds that the input data should be hashed.</param>
     /// <returns>Returns the computed hash value.</returns>
     public static byte[] ComputeHash(this HashAlgorithm algorithm, ReadOnlySpan<char> data, Encoding? encoding = null, int rounds = 1) =>
-        algorithm.ComputeHash((encoding ?? Encoding.UTF8).GetBytes(data.ToArray()), rounds);
+        algorithm.ComputeHash(encoding.GetOrDefault().GetBytes(data.ToArray()), rounds);
 
     /// <summary>
     /// Computes the hash value for the specified <see cref="Stream"/> object.

--- a/OnixLabs.Security.Cryptography/Extensions.HashAlgorithm.cs
+++ b/OnixLabs.Security.Cryptography/Extensions.HashAlgorithm.cs
@@ -98,7 +98,7 @@ public static class HashAlgorithmExtensions
     /// <param name="token">The token to monitor for cancellation requests.</param>
     /// <returns>Returns a task that represents the asynchronous compute hash operation and wraps the computed hash value.</returns>
     public static async Task<byte[]> ComputeHashAsync(this HashAlgorithm algorithm, IBinaryConvertible data, int rounds = 1, CancellationToken token = default) =>
-        await algorithm.ComputeHashAsync(new MemoryStream(data.ToByteArray()), rounds, token);
+        await algorithm.ComputeHashAsync(new MemoryStream(data.ToByteArray()), rounds, token).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously computes the hash value for the specified <see cref="Stream"/> object.
@@ -112,8 +112,8 @@ public static class HashAlgorithmExtensions
     {
         Require(rounds > 0, "Rounds must be greater than zero", nameof(rounds));
 
-        MemoryStream memoryStream = new(await algorithm.ComputeHashAsync(stream, token));
-        while (--rounds > 0) memoryStream = new MemoryStream(await algorithm.ComputeHashAsync(memoryStream, token));
+        MemoryStream memoryStream = new(await algorithm.ComputeHashAsync(stream, token).ConfigureAwait(false));
+        while (--rounds > 0) memoryStream = new MemoryStream(await algorithm.ComputeHashAsync(memoryStream, token).ConfigureAwait(false));
         return memoryStream.ToArray();
     }
 }

--- a/OnixLabs.Security.Cryptography/Extensions.cs
+++ b/OnixLabs.Security.Cryptography/Extensions.cs
@@ -32,9 +32,9 @@ public static class Extensions
     public static Hash ToHash(this byte[] value) => value;
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Hash"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Hash"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Hash"/> instance.</returns>
     public static Hash ToHash(this ReadOnlySpan<byte> value) => value;
 
@@ -46,9 +46,9 @@ public static class Extensions
     public static Secret ToSecret(this byte[] value) => value;
 
     /// <summary>
-    /// Converts the current <see cref="ReadOnlySpan{Byte}"/> into a new <see cref="Secret"/> instance.
+    /// Converts the current <see cref="ReadOnlySpan{T}"/> into a new <see cref="Secret"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySpan{Byte}"/> value to convert.</param>
+    /// <param name="value">The <see cref="ReadOnlySpan{T}"/> value to convert.</param>
     /// <returns>Returns a new <see cref="Secret"/> instance.</returns>
     public static Secret ToSecret(this ReadOnlySpan<byte> value) => value;
 }

--- a/OnixLabs.Security.Cryptography/Hash.Compute.cs
+++ b/OnixLabs.Security.Cryptography/Hash.Compute.cs
@@ -114,7 +114,7 @@ public readonly partial struct Hash
     /// <param name="token">The token to monitor for cancellation requests.</param>
     /// <returns>Returns a cryptographic hash of the specified data.</returns>
     public static async Task<Hash> ComputeAsync(HashAlgorithm algorithm, Stream stream, CancellationToken token = default) =>
-        await algorithm.ComputeHashAsync(stream, token);
+        await algorithm.ComputeHashAsync(stream, token).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously computes the hash of the specified data, using the specified <see cref="HashAlgorithm"/>.
@@ -125,7 +125,7 @@ public readonly partial struct Hash
     /// <param name="token">The token to monitor for cancellation requests.</param>
     /// <returns>Returns a cryptographic hash of the specified data.</returns>
     public static async Task<Hash> ComputeAsync(HashAlgorithm algorithm, Stream stream, int rounds, CancellationToken token = default) =>
-        await algorithm.ComputeHashAsync(stream, rounds, token);
+        await algorithm.ComputeHashAsync(stream, rounds, token).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously computes the hash of the specified data, using the specified <see cref="HashAlgorithm"/>.
@@ -136,5 +136,5 @@ public readonly partial struct Hash
     /// <param name="token">The token to monitor for cancellation requests.</param>
     /// <returns>Returns a cryptographic hash of the specified data.</returns>
     public static async Task<Hash> ComputeAsync(HashAlgorithm algorithm, IBinaryConvertible data, int rounds = 1, CancellationToken token = default) =>
-        await algorithm.ComputeHashAsync(data, rounds, token);
+        await algorithm.ComputeHashAsync(data, rounds, token).ConfigureAwait(false);
 }

--- a/OnixLabs.Security.Cryptography/Hash.Compute.cs
+++ b/OnixLabs.Security.Cryptography/Hash.Compute.cs
@@ -96,11 +96,11 @@ public readonly partial struct Hash
         algorithm.ComputeHash(data, rounds);
 
     /// <summary>
-    /// Computes the hash value for the specified <see cref="ReadOnlySpan{Char}"/>.
+    /// Computes the hash value for the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="algorithm">The <see cref="HashAlgorithm"/> which will be used to compute a hash value.</param>
     /// <param name="data">The input data to compute the hash for.</param>
-    /// <param name="encoding">The <see cref="Encoding"/> which will be used to convert the specified <see cref="ReadOnlySpan{Char}"/>.</param>
+    /// <param name="encoding">The <see cref="Encoding"/> which will be used to convert the specified <see cref="ReadOnlySpan{T}"/>.</param>
     /// <param name="rounds">The number of rounds that the input data should be hashed.</param>
     /// <returns>Returns a cryptographic hash of the specified data.</returns>
     public static Hash Compute(HashAlgorithm algorithm, ReadOnlySpan<char> data, Encoding? encoding = null, int rounds = 1) =>

--- a/OnixLabs.Security.Cryptography/Hash.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/Hash.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public readonly partial struct Hash
     /// Create a new <see cref="Hash"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Hash"/> instance.</param>
-    /// <returns>Returns a new <see cref="Hash"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Hash"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Hash(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="Hash"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="Hash"/> instance.</param>
+    /// <returns>Returns a new <see cref="Hash"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator Hash(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/Hash.Parse.cs
+++ b/OnixLabs.Security.Cryptography/Hash.Parse.cs
@@ -28,11 +28,11 @@ public readonly partial struct Hash
     public static Hash Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="Hash"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="Hash"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="Hash"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Hash"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static Hash Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out Hash result)) return result;
@@ -52,13 +52,13 @@ public readonly partial struct Hash
     public static bool TryParse(string? value, IFormatProvider? provider, out Hash result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="Hash"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="Hash"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="Hash"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="Hash"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="Hash"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="Hash"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out Hash result)

--- a/OnixLabs.Security.Cryptography/Hash.cs
+++ b/OnixLabs.Security.Cryptography/Hash.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 using System.Linq;
 using OnixLabs.Core;
 
@@ -24,7 +25,11 @@ namespace OnixLabs.Security.Cryptography;
 /// <param name="value">The underlying value of the cryptographic hash.</param>
 public readonly partial struct Hash(ReadOnlySpan<byte> value) : ICryptoPrimitive<Hash>, IValueComparable<Hash>, ISpanParsable<Hash>
 {
-    private readonly byte[] value = value.ToArray();
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Hash"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="Hash"/> instance.</param>
+    public Hash(ReadOnlySequence<byte> value) : this(ReadOnlySpan<byte>.Empty) => value.CopyTo(out this.value);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Hash"/> struct.
@@ -34,4 +39,6 @@ public readonly partial struct Hash(ReadOnlySpan<byte> value) : ICryptoPrimitive
     public Hash(byte value, int length) : this(Enumerable.Repeat(value, length).ToArray())
     {
     }
+
+    private readonly byte[] value = value.ToArray();
 }

--- a/OnixLabs.Security.Cryptography/IEcdsaPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/IEcdsaPrivateKey.cs
@@ -25,7 +25,7 @@ namespace OnixLabs.Security.Cryptography;
 public interface IEcdsaPrivateKey : IPublicKeyExportable<EcdsaPublicKey>, IPrivateKeyImportablePkcs8<EcdsaPrivateKey>, IPrivateKeyExportablePkcs8, IBinaryConvertible
 {
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -34,7 +34,7 @@ public interface IEcdsaPrivateKey : IPublicKeyExportable<EcdsaPublicKey>, IPriva
     byte[] SignData(ReadOnlySpan<byte> data, HashAlgorithm algorithm, DSASignatureFormat format = default);
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -63,7 +63,7 @@ public interface IEcdsaPrivateKey : IPublicKeyExportable<EcdsaPublicKey>, IPriva
     byte[] SignData(IBinaryConvertible data, HashAlgorithm algorithm, DSASignatureFormat format = default);
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -72,7 +72,7 @@ public interface IEcdsaPrivateKey : IPublicKeyExportable<EcdsaPublicKey>, IPriva
     byte[] SignData(ReadOnlySpan<byte> data, HashAlgorithmName algorithm, DSASignatureFormat format = default);
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -109,7 +109,7 @@ public interface IEcdsaPrivateKey : IPublicKeyExportable<EcdsaPublicKey>, IPriva
     byte[] SignHash(Hash hash, DSASignatureFormat format = default);
 
     /// <summary>
-    /// Signs the specified <see cref="ReadOnlySpan{Byte}"/>.
+    /// Signs the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="hash">The hash to sign.</param>
     /// <param name="format">The digital signature format which will be used to generate the cryptographic digital signature.</param>

--- a/OnixLabs.Security.Cryptography/IRsaPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/IRsaPrivateKey.cs
@@ -25,7 +25,7 @@ namespace OnixLabs.Security.Cryptography;
 public interface IRsaPrivateKey : IPublicKeyExportable<RsaPublicKey>, IPrivateKeyImportablePkcs8<RsaPrivateKey>, IPrivateKeyExportablePkcs8, IBinaryConvertible
 {
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -34,7 +34,7 @@ public interface IRsaPrivateKey : IPublicKeyExportable<RsaPublicKey>, IPrivateKe
     byte[] SignData(ReadOnlySpan<byte> data, HashAlgorithmName algorithm, RSASignaturePadding padding);
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -72,7 +72,7 @@ public interface IRsaPrivateKey : IPublicKeyExportable<RsaPublicKey>, IPrivateKe
     byte[] SignHash(Hash hash, HashAlgorithmName algorithm, RSASignaturePadding padding);
 
     /// <summary>
-    /// Signs the specified <see cref="ReadOnlySpan{Byte}"/>.
+    /// Signs the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="hash">The hash to sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input hash.</param>

--- a/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
+++ b/OnixLabs.Security.Cryptography/OnixLabs.Security.Cryptography.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security.Cryptography</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Cryptography API for .NET</Description>
-        <AssemblyVersion>8.15.0</AssemblyVersion>
+        <AssemblyVersion>8.16.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.15.0</PackageVersion>
+        <PackageVersion>8.16.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>

--- a/OnixLabs.Security.Cryptography/PrivateKey.To.cs
+++ b/OnixLabs.Security.Cryptography/PrivateKey.To.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using OnixLabs.Core;
 using OnixLabs.Core.Text;
 
@@ -31,7 +32,15 @@ public abstract partial class PrivateKey
     /// </summary>
     /// <param name="algorithmName">The name of the algorithm that was used to produce the associated private key.</param>
     /// <returns>Returns a new <see cref="NamedPrivateKey"/> from the current <see cref="PrivateKey"/> instance.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Passing custom algorithm names can lead to named keys. Use the parameterless ToNamedPrivateKey method instead.")]
     public NamedPrivateKey ToNamedPrivateKey(string algorithmName) => new(this, algorithmName);
+
+    /// <summary>
+    /// Creates a new <see cref="NamedPrivateKey"/> from the current <see cref="PrivateKey"/> instance.
+    /// </summary>
+    /// <returns>Returns a new <see cref="NamedPrivateKey"/> from the current <see cref="PrivateKey"/> instance.</returns>
+    public abstract NamedPrivateKey ToNamedPrivateKey();
 
     /// <summary>
     /// Returns a <see cref="string"/> that represents the current object.

--- a/OnixLabs.Security.Cryptography/PrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/PrivateKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 

--- a/OnixLabs.Security.Cryptography/PublicKey.To.cs
+++ b/OnixLabs.Security.Cryptography/PublicKey.To.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using OnixLabs.Core;
 using OnixLabs.Core.Text;
 
@@ -31,7 +32,15 @@ public abstract partial class PublicKey
     /// </summary>
     /// <param name="algorithmName">The name of the algorithm that was used to produce the associated public key.</param>
     /// <returns>Returns a new <see cref="NamedPublicKey"/> from the current <see cref="PublicKey"/> instance.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Passing custom algorithm names can lead to named keys. Use the parameterless ToNamedPublicKey method instead.")]
     public NamedPublicKey ToNamedPublicKey(string algorithmName) => new(this, algorithmName);
+
+    /// <summary>
+    /// Creates a new <see cref="NamedPublicKey"/> from the current <see cref="PublicKey"/> instance.
+    /// </summary>
+    /// <returns>Returns a new <see cref="NamedPublicKey"/> from the current <see cref="PublicKey"/> instance.</returns>
+    public abstract NamedPublicKey ToNamedPublicKey();
 
     /// <summary>
     /// Returns a <see cref="string"/> that represents the current object.

--- a/OnixLabs.Security.Cryptography/RsaPrivateKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/RsaPrivateKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class RsaPrivateKey
     /// Create a new <see cref="RsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="RsaPrivateKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="RsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="RsaPrivateKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator RsaPrivateKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="RsaPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="RsaPrivateKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="RsaPrivateKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator RsaPrivateKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/RsaPrivateKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/RsaPrivateKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class RsaPrivateKey
     public static RsaPrivateKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="RsaPrivateKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="RsaPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="RsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="RsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static RsaPrivateKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out RsaPrivateKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class RsaPrivateKey
     public static bool TryParse(string? value, IFormatProvider? provider, out RsaPrivateKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="RsaPrivateKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="RsaPrivateKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="RsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="RsaPrivateKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="RsaPrivateKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="RsaPrivateKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out RsaPrivateKey result)

--- a/OnixLabs.Security.Cryptography/RsaPrivateKey.Sign.cs
+++ b/OnixLabs.Security.Cryptography/RsaPrivateKey.Sign.cs
@@ -22,7 +22,7 @@ namespace OnixLabs.Security.Cryptography;
 public sealed partial class RsaPrivateKey
 {
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input data.</param>
@@ -35,7 +35,7 @@ public sealed partial class RsaPrivateKey
     }
 
     /// <summary>
-    /// Hashes the specified <see cref="ReadOnlySpan{Byte}"/> data and signs the resulting hash.
+    /// Hashes the specified <see cref="ReadOnlySpan{T}"/> data and signs the resulting hash.
     /// </summary>
     /// <param name="data">The input data to hash and sign.</param>
     /// <param name="offset">The offset into the byte array from which to begin using data.</param>
@@ -89,7 +89,7 @@ public sealed partial class RsaPrivateKey
     }
 
     /// <summary>
-    /// Signs the specified <see cref="ReadOnlySpan{Byte}"/>.
+    /// Signs the specified <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     /// <param name="hash">The hash to sign.</param>
     /// <param name="algorithm">The hash algorithm that will be used to hash the input hash.</param>

--- a/OnixLabs.Security.Cryptography/RsaPrivateKey.To.cs
+++ b/OnixLabs.Security.Cryptography/RsaPrivateKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class RsaPrivateKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPrivateKey"/> from the current <see cref="RsaPrivateKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPrivateKey"/> from the current <see cref="RsaPrivateKey"/> instance.</returns>
+    public override NamedPrivateKey ToNamedPrivateKey() => new(this, "RSA");
 }

--- a/OnixLabs.Security.Cryptography/RsaPrivateKey.cs
+++ b/OnixLabs.Security.Cryptography/RsaPrivateKey.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -20,4 +21,13 @@ namespace OnixLabs.Security.Cryptography;
 /// Represents an RSA cryptographic private key.
 /// </summary>
 /// <param name="keyData">The underlying key data of the RSA cryptographic private key.</param>
-public sealed partial class RsaPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IRsaPrivateKey, ISpanParsable<RsaPrivateKey>;
+public sealed partial class RsaPrivateKey(ReadOnlySpan<byte> keyData) : PrivateKey(keyData), IRsaPrivateKey, ISpanParsable<RsaPrivateKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RsaPrivateKey"/> struct.
+    /// </summary>
+    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPrivateKey"/> instance.</param>
+    public RsaPrivateKey(ReadOnlySequence<byte> value) : this(value.ToArray())
+    {
+    }
+}

--- a/OnixLabs.Security.Cryptography/RsaPublicKey.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/RsaPublicKey.Convertible.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Buffers;
 
 namespace OnixLabs.Security.Cryptography;
 
@@ -29,6 +30,13 @@ public sealed partial class RsaPublicKey
     /// Create a new <see cref="RsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="RsaPublicKey"/> instance.</param>
-    /// <returns>Returns a new <see cref="RsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="RsaPublicKey"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator RsaPublicKey(ReadOnlySpan<byte> value) => new(value);
+
+    /// <summary>
+    /// Create a new <see cref="RsaPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
+    /// </summary>
+    /// <param name="value">The value from which to create a new <see cref="RsaPublicKey"/> instance.</param>
+    /// <returns>Returns a new <see cref="RsaPublicKey"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
+    public static implicit operator RsaPublicKey(ReadOnlySequence<byte> value) => new(value);
 }

--- a/OnixLabs.Security.Cryptography/RsaPublicKey.Parse.cs
+++ b/OnixLabs.Security.Cryptography/RsaPublicKey.Parse.cs
@@ -28,11 +28,11 @@ public sealed partial class RsaPublicKey
     public static RsaPublicKey Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="RsaPublicKey"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="RsaPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="RsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="RsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static RsaPublicKey Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out RsaPublicKey result)) return result;
@@ -52,13 +52,13 @@ public sealed partial class RsaPublicKey
     public static bool TryParse(string? value, IFormatProvider? provider, out RsaPublicKey result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="RsaPublicKey"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="RsaPublicKey"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="RsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="RsaPublicKey"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="RsaPublicKey"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="RsaPublicKey"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out RsaPublicKey result)

--- a/OnixLabs.Security.Cryptography/RsaPublicKey.To.cs
+++ b/OnixLabs.Security.Cryptography/RsaPublicKey.To.cs
@@ -12,22 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Buffers;
-
 namespace OnixLabs.Security.Cryptography;
 
-/// <summary>
-/// Represents an RSA cryptographic public key.
-/// </summary>
-/// <param name="keyData">The underlying key data of the RSA cryptographic public key.</param>
-public sealed partial class RsaPublicKey(ReadOnlySpan<byte> keyData) : PublicKey(keyData), IRsaPublicKey, ISpanParsable<RsaPublicKey>
+public sealed partial class RsaPublicKey
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RsaPublicKey"/> struct.
+    /// Creates a new <see cref="NamedPublicKey"/> from the current <see cref="RsaPublicKey"/> instance.
     /// </summary>
-    /// <param name="value">The <see cref="ReadOnlySequence{T}"/> with which to initialize the <see cref="RsaPublicKey"/> instance.</param>
-    public RsaPublicKey(ReadOnlySequence<byte> value) : this(value.ToArray())
-    {
-    }
+    /// <returns>Returns a new <see cref="NamedPublicKey"/> from the current <see cref="RsaPublicKey"/> instance.</returns>
+    public override NamedPublicKey ToNamedPublicKey() => new(this, "RSA");
 }

--- a/OnixLabs.Security.Cryptography/Secret.Convertible.cs
+++ b/OnixLabs.Security.Cryptography/Secret.Convertible.cs
@@ -31,7 +31,7 @@ public readonly partial struct Secret
     /// Create a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Secret"/> instance.</param>
-    /// <returns>Returns a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static implicit operator Secret(ReadOnlySpan<byte> value) => new(value);
 
     /// <summary>
@@ -52,9 +52,9 @@ public readonly partial struct Secret
 
     /// <summary>
     /// Create a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.
-    /// <remarks>The <see cref="ReadOnlySequence{Char}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
+    /// <remarks>The <see cref="ReadOnlySequence{T}"/> value will be encoded using the <see cref="Encoding.UTF8"/> encoding.</remarks>
     /// </summary>
     /// <param name="value">The value from which to create a new <see cref="Secret"/> instance.</param>
-    /// <returns>Returns a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySequence{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Secret"/> instance from the specified <see cref="ReadOnlySequence{T}"/> value.</returns>
     public static implicit operator Secret(ReadOnlySequence<char> value) => new(Encoding.UTF8.GetBytes(value));
 }

--- a/OnixLabs.Security.Cryptography/Secret.Parse.cs
+++ b/OnixLabs.Security.Cryptography/Secret.Parse.cs
@@ -28,11 +28,11 @@ public readonly partial struct Secret
     public static Secret Parse(string value, IFormatProvider? provider = null) => Parse(value.AsSpan(), provider);
 
     /// <summary>
-    /// Parses the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="Secret"/> value.
+    /// Parses the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="Secret"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
-    /// <returns>Returns a new <see cref="Secret"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value.</returns>
+    /// <returns>Returns a new <see cref="Secret"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value.</returns>
     public static Secret Parse(ReadOnlySpan<char> value, IFormatProvider? provider = null)
     {
         if (TryParse(value, provider, out Secret result)) return result;
@@ -52,13 +52,13 @@ public readonly partial struct Secret
     public static bool TryParse(string? value, IFormatProvider? provider, out Secret result) => TryParse(value.AsSpan(), provider, out result);
 
     /// <summary>
-    /// Tries to parse the specified <see cref="ReadOnlySpan{Char}"/> value into a <see cref="Secret"/> value.
+    /// Tries to parse the specified <see cref="ReadOnlySpan{T}"/> value into a <see cref="Secret"/> value.
     /// </summary>
     /// <param name="value">The value to parse.</param>
     /// <param name="provider">The format provider that will be used to decode the specified value.</param>
     /// <param name="result">
-    /// A new <see cref="Secret"/> instance, parsed from the specified <see cref="ReadOnlySpan{Char}"/> value, or the default
-    /// <see cref="Secret"/> value if the specified <see cref="ReadOnlySpan{Char}"/> could not be parsed.
+    /// A new <see cref="Secret"/> instance, parsed from the specified <see cref="ReadOnlySpan{T}"/> value, or the default
+    /// <see cref="Secret"/> value if the specified <see cref="ReadOnlySpan{T}"/> could not be parsed.
     /// </param>
     /// <returns>Returns <see langword="true"/> if the specified value was decoded successfully; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider? provider, out Secret result)

--- a/OnixLabs.Security/OnixLabs.Security.csproj
+++ b/OnixLabs.Security/OnixLabs.Security.csproj
@@ -4,13 +4,13 @@
         <Title>OnixLabs.Security</Title>
         <Authors>ONIXLabs</Authors>
         <Description>ONIXLabs Security API for .NET</Description>
-        <AssemblyVersion>8.15.0</AssemblyVersion>
+        <AssemblyVersion>8.16.0</AssemblyVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Copyright>Copyright © ONIXLabs 2020</Copyright>
         <RepositoryUrl>https://github.com/onix-labs/onixlabs-dotnet</RepositoryUrl>
-        <PackageVersion>8.15.0</PackageVersion>
+        <PackageVersion>8.16.0</PackageVersion>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup>


### PR DESCRIPTION
Added constructors for `ReadOnlySequence<T>`, pre-condition `CheckNotNull` and `RequireNotNull` overloads for dealing with nullable structs, and auto-named public/private keys.